### PR TITLE
Cache types and function type resolution

### DIFF
--- a/include/orange/AST.h
+++ b/include/orange/AST.h
@@ -214,17 +214,6 @@ public:
 		}
 	}
 
-	/**
-	 * Fixes up the type of this object, intended for use during the analysis pass. Objects 
-	 * can look at the types of siblings and static attributes of parents to further 
-	 * determine their types.
-	 */ 
-	virtual void fixup() {
-		for (auto child : m_children) {
-			child->fixup();
-		}
-	}
-
 	virtual ~ASTNode() { };
 };
 

--- a/include/orange/AST.h
+++ b/include/orange/AST.h
@@ -202,7 +202,7 @@ public:
 
 	ASTNode* root() const; 
 
-	std::string dump();
+	virtual std::string dump();
 
 	/**
 	 * Resolves this object, intended for use during the analysis pass. This function's body 

--- a/include/orange/AST.h
+++ b/include/orange/AST.h
@@ -70,17 +70,9 @@ protected:
 	/** 
 	 * Adds a child to the list of children.
 	 */
-	void addChild(ASTNode* child) {
-		if (child == nullptr) return; 
-		child->setParent(this);
-		m_children.push_back(child);
-	}
+	void addChild(ASTNode* child);
 
-	void addChild(std::string tag, ASTNode* child) {
-		if (child == nullptr) return;
-		child->setParent(this);
-		m_children.push_back(child);
-	}
+	void addChild(std::string tag, ASTNode* child);
 
 	bool m_resolved = false;
 
@@ -223,6 +215,11 @@ public:
 			child->resolve();
 		}
 	}
+
+	/**
+	 * Request a new ID.
+	 */
+	void newID();
 
 	ASTNode();
 	virtual ~ASTNode() { };

--- a/include/orange/AST.h
+++ b/include/orange/AST.h
@@ -83,6 +83,8 @@ protected:
 	}
 
 	bool m_resolved = false;
+
+	unsigned long m_ID = 0;
 public:
 	/**
 	 * Gets the name of the class. Children classes will override this method to return the 
@@ -91,6 +93,8 @@ public:
 	 * @return The name of this class. Each instance of this class will return the same value.
 	 */ 
 	virtual std::string getClass() { return "ASTNode"; }
+
+	unsigned long ID() const { return m_ID; }
 
 	std::string tag() const { return m_tag; }
 	void setTag(std::string tag) { m_tag = tag; }
@@ -220,6 +224,7 @@ public:
 		}
 	}
 
+	ASTNode();
 	virtual ~ASTNode() { };
 };
 

--- a/include/orange/AST.h
+++ b/include/orange/AST.h
@@ -60,6 +60,11 @@ protected:
 	 */
 	ASTNode* m_parent = nullptr; 
 
+	/**
+	 * The dependency of this node.
+	 */
+	ASTNode* m_dependency = nullptr;
+
 	/** 
 	 * The children for this node, if any.
 	 */
@@ -106,6 +111,8 @@ public:
 	void copyProperties(ASTNode* from) {
 		setLocation(from->location());
 	}
+
+	ASTNode* dependency() const { return m_dependency; }
 
 	bool resolved() const { return m_resolved; }
 
@@ -207,10 +214,21 @@ public:
 	}
 
 	/**
+	 * Determines what node this node depends on being resolved.
+	 */ 
+	virtual void mapDependencies() {
+		for (auto child : m_children) {
+			child->mapDependencies();
+		}
+	}
+
+	/**
 	 * Resolves this object, intended for use during the analysis pass. This function's body 
 	 * will only ever excecute once, to avoid unnecessary duplication of code.
 	 */
 	virtual void resolve() { 
+		if (m_dependency) m_dependency->resolve();
+
 		for (auto child : m_children) {
 			child->resolve();
 		}

--- a/include/orange/AST.h
+++ b/include/orange/AST.h
@@ -204,6 +204,12 @@ public:
 
 	virtual std::string dump();
 
+	virtual void initialize() {
+		for (auto child : m_children) {
+			child->initialize();
+		}
+	}
+
 	/**
 	 * Resolves this object, intended for use during the analysis pass. This function's body 
 	 * will only ever excecute once, to avoid unnecessary duplication of code.

--- a/include/orange/AddressOfExpr.h
+++ b/include/orange/AddressOfExpr.h
@@ -23,8 +23,6 @@ public:
 
 	virtual ASTNode* clone();
 
-	virtual OrangeTy* getType();
-
 	virtual void resolve();
 
 	AddressOfExpr(Expression* expr);

--- a/include/orange/AnyID.h
+++ b/include/orange/AnyID.h
@@ -50,11 +50,6 @@ public:
 
 	virtual Expression* expression(); 
 
-	/**
-	 * Creates a new VarExpr and sets it as the m_any_expr.
-	 */
-	virtual void newVarExpr(); 
-
 	AnyID(std::string name);
 };
 

--- a/include/orange/AnyID.h
+++ b/include/orange/AnyID.h
@@ -42,6 +42,8 @@ public:
 
 	virtual OrangeTy* getType();
 
+	virtual void mapDependencies();
+
 	virtual void resolve();
 
 	virtual bool isSigned();

--- a/include/orange/ArrayAccess.h
+++ b/include/orange/ArrayAccess.h
@@ -25,8 +25,6 @@ public:
 
 	virtual std::string string();
 
-	virtual OrangeTy* getType();
-
 	virtual void resolve();
 
 	virtual bool returnsPtr() { return true; }

--- a/include/orange/ArrayExpr.h
+++ b/include/orange/ArrayExpr.h
@@ -29,7 +29,7 @@ public:
 
 	virtual std::string string();
 
-	virtual OrangeTy* getType();
+	virtual void resolve();
 
 	/**
 	 * Returns whether or not all the elements of the array 

--- a/include/orange/BinOpExpr.h
+++ b/include/orange/BinOpExpr.h
@@ -106,12 +106,12 @@ public:
 	virtual Value* Codegen();
 
 	virtual ASTNode* clone() {
-		return new BinOpExpr((Expression*)m_LHS->clone(), m_op, (Expression*)m_RHS->clone());
+		auto clone = new BinOpExpr((Expression*)m_LHS->clone(), m_op, (Expression*)m_RHS->clone());
+		clone->copyProperties(this);
+		return clone;
 	}
 
 	virtual std::string string();
-
-	virtual OrangeTy* getType();
 
 	virtual void resolve();
 

--- a/include/orange/Block.h
+++ b/include/orange/Block.h
@@ -12,6 +12,8 @@
 #include "AST.h"
 #include "SymTable.h"
 
+class ReturnStmt;
+
 class Block : public Statement {
 private:
 	/**

--- a/include/orange/Block.h
+++ b/include/orange/Block.h
@@ -81,6 +81,8 @@ public:
 	 */
 	bool hasReturn();
 
+	bool hasReturnNested();
+
 	/**
 	 * Determines whether or not the body will jump.
 	 * Does not check for nested bodies. 

--- a/include/orange/Block.h
+++ b/include/orange/Block.h
@@ -33,16 +33,6 @@ protected:
 	 * Generates all of the statements.
 	 */
 	void generateStatements();	
-
-	/** 
-	 * Pushes this to the symtable.
-	 */
-	void pushBlock();
-
-	/**
-	 * Pops this from the symtable.
-	 */
-	void popBlock(); 
 public:
 	virtual std::string getClass() { return "Block"; }
 
@@ -123,6 +113,16 @@ public:
 	 * This will resolve every statement added to this block.
 	 */
 	void resolve();
+
+	/** 
+	 * Pushes this to the symtable.
+	 */
+	void pushBlock();
+
+	/**
+	 * Pops this from the symtable.
+	 */
+	void popBlock(); 
 
 	/**
 	 * Creates a block. Every block must have a symbol table attached to 

--- a/include/orange/Block.h
+++ b/include/orange/Block.h
@@ -109,6 +109,8 @@ public:
 
 	virtual std::string string();
 
+	void initialize();
+
 	/**
 	 * This will resolve every statement added to this block.
 	 */

--- a/include/orange/Block.h
+++ b/include/orange/Block.h
@@ -109,6 +109,8 @@ public:
 
 	virtual std::string string();
 
+	void mapDependencies();
+
 	void initialize();
 
 	/**

--- a/include/orange/CastExpr.h
+++ b/include/orange/CastExpr.h
@@ -13,7 +13,6 @@
 
 class CastExpr : public Expression {
 private:
-	OrangeTy* m_type; 
 	Expression* m_expr;
 public:
 	virtual std::string getClass() { return "CastExpr"; }
@@ -23,8 +22,6 @@ public:
 	virtual Value* Codegen();
 
 	virtual ASTNode* clone();
-
-	virtual OrangeTy* getType();
 
 	virtual bool isSigned();
 

--- a/include/orange/CodeElement.h
+++ b/include/orange/CodeElement.h
@@ -16,7 +16,7 @@ public:
 
 	CodeLocation() {};
 	CodeLocation(int row_begin, int row_end, int col_begin, int col_end) : row_begin(row_begin), row_end(row_end), 
-		col_begin(col_begin), col_end(col_end) { }
+		col_begin(col_begin-1), col_end(col_end-1) { }
 };
 
 /**

--- a/include/orange/DerefExpr.h
+++ b/include/orange/DerefExpr.h
@@ -23,11 +23,11 @@ public:
 
 	virtual ASTNode* clone();
 
-	virtual OrangeTy* getType();
-
 	virtual bool isSigned();
 
 	virtual bool returnsPtr();
+
+	virtual void resolve();
 
 	DerefExpr(Expression* expr);
 };

--- a/include/orange/DotExpr.h
+++ b/include/orange/DotExpr.h
@@ -28,8 +28,6 @@ public:
 
 	virtual ASTNode* clone();
 
-	virtual OrangeTy* getType();
-
 	virtual void resolve();
 
 	virtual bool isSigned();

--- a/include/orange/EnumStmt.h
+++ b/include/orange/EnumStmt.h
@@ -39,6 +39,8 @@ public:
 
 	virtual std::string name() const { return m_name; }
 
+	virtual void initialize();
+
 	virtual void resolve();
 
 	virtual void addEnum(std::string name);

--- a/include/orange/EnumStmt.h
+++ b/include/orange/EnumStmt.h
@@ -35,8 +35,6 @@ public:
 
 	virtual ASTNode* clone();
 
-	virtual OrangeTy* getType();
-
 	virtual std::string string();
 
 	virtual std::string name() const { return m_name; }

--- a/include/orange/ExplicitDeclStmt.h
+++ b/include/orange/ExplicitDeclStmt.h
@@ -37,8 +37,6 @@ public:
 
 	virtual ASTNode* clone();
 
-	virtual OrangeTy* getType();
-
 	virtual bool isSigned();
 
 	virtual void resolve();

--- a/include/orange/ExternFunction.h
+++ b/include/orange/ExternFunction.h
@@ -30,6 +30,8 @@ public:
 		return clone; 
 	}
 
+	virtual void initialize();
+
 	virtual void resolve();
 
 	virtual bool isSigned() { return m_type->isSigned(); }

--- a/include/orange/ExternFunction.h
+++ b/include/orange/ExternFunction.h
@@ -15,7 +15,6 @@
 
 class ExternFunction : public Statement {
 private:
-	OrangeTy* m_type;
 	std::string m_name;
 	ParamList m_parameters;
 public:
@@ -26,12 +25,12 @@ public:
 	virtual Value* Codegen();
 
 	virtual ASTNode* clone() {
-		return new ExternFunction(m_type, m_name, m_parameters);
+		auto clone = new ExternFunction(m_type, m_name, m_parameters);
+		clone->copyProperties(this);
+		return clone; 
 	}
 
 	virtual void resolve();
-
-	virtual OrangeTy* getType() { return m_type; }
 
 	virtual bool isSigned() { return m_type->isSigned(); }
 

--- a/include/orange/FuncCall.h
+++ b/include/orange/FuncCall.h
@@ -37,6 +37,8 @@ public:
 	 */
 	virtual bool isSigned();
 
+	std::string name() const { return m_name; }
+
 	FuncCall(std::string name);
 	FuncCall(std::string name, ArgList arguments);
 }; 

--- a/include/orange/FuncCall.h
+++ b/include/orange/FuncCall.h
@@ -25,8 +25,6 @@ public:
 
 	virtual std::string string();
 
-	virtual OrangeTy *getType();
-
 	virtual void resolve();
 
 	/** 

--- a/include/orange/FuncCall.h
+++ b/include/orange/FuncCall.h
@@ -25,6 +25,8 @@ public:
 
 	virtual std::string string();
 
+	virtual void mapDependencies();
+
 	virtual void resolve();
 
 	/** 

--- a/include/orange/FunctionStmt.h
+++ b/include/orange/FunctionStmt.h
@@ -42,12 +42,6 @@ private:
 	 */
 	Value* m_retVal = nullptr;
 	
-	/**
-	 * Indicates that we're currently looking in our body for a return statement.
-	 * Avoids infinite recursion.
-	 */
-	bool m_looking = false;
-
 	ParamList m_parameters;
 
 	std::vector<FunctionStmt*> m_clones;

--- a/include/orange/FunctionStmt.h
+++ b/include/orange/FunctionStmt.h
@@ -126,6 +126,8 @@ public:
 	 */
 	BasicBlock* createBasicBlock(std::string name);
 
+	virtual void initialize();
+
 	/** 
 	 * Gets the parent symbol table, if there is one. 
 	 * If there is a parent symbol table, adds this to the 

--- a/include/orange/FunctionStmt.h
+++ b/include/orange/FunctionStmt.h
@@ -30,8 +30,6 @@ private:
 	// TODO: clones of this function should be LinkOnceODRLinkage.
 	llvm::GlobalValue::LinkageTypes m_linkageType = Function::ExternalLinkage;
 
-	OrangeTy* m_type = IDTy::get();
-
 	/**
 	 * Indicates the exit block of the function to jump to when returning a value.
 	 */
@@ -52,6 +50,8 @@ private:
 	 * Set to true when the name has been mangled.
 	 */
 	bool m_mangled = false;
+
+	bool m_type_set = false;
 public:
 	virtual std::string getClass() { return "FunctionStmt"; }
 
@@ -60,8 +60,6 @@ public:
 	virtual ASTNode* clone();
 
 	virtual std::string string();
-
-	virtual OrangeTy* getType();
 
 	virtual std::string name() const { return m_name; }
 
@@ -107,6 +105,8 @@ public:
 	 *	type signature.
 	 */
 	virtual FunctionStmt* createGenericClone(ArgList args);
+
+	virtual FunctionStmt* getGenericClone(ArgList args);
 
 	/** 
 	 * Gets the exit block of the function to jump to when returning a value.

--- a/include/orange/FunctionStmt.h
+++ b/include/orange/FunctionStmt.h
@@ -126,6 +126,8 @@ public:
 	 */
 	BasicBlock* createBasicBlock(std::string name);
 
+	virtual void mapDependencies();
+
 	virtual void initialize();
 
 	/** 

--- a/include/orange/FunctionStmt.h
+++ b/include/orange/FunctionStmt.h
@@ -133,6 +133,8 @@ public:
 	 */
 	virtual void resolve();
 
+	std::string dump();
+
 	/** 
 	 * If set before resolve, will disable name mangling. 
 	 */

--- a/include/orange/IncrementExpr.h
+++ b/include/orange/IncrementExpr.h
@@ -26,8 +26,6 @@ public:
 
 	virtual ASTNode* clone();
 
-	virtual OrangeTy* getType();
-
 	virtual void resolve();
 
 	virtual bool isSigned();

--- a/include/orange/Loop.h
+++ b/include/orange/Loop.h
@@ -162,6 +162,8 @@ public:
 
 	virtual ASTNode* clone();
 
+	virtual void initialize();
+
 	virtual void resolve();
 
 	/**

--- a/include/orange/LoopSkip.h
+++ b/include/orange/LoopSkip.h
@@ -25,7 +25,9 @@ public:
 	virtual Value* Codegen();
 
 	virtual ASTNode* clone() {
-		return new LoopSkip(m_continue);
+		auto clone = new LoopSkip(m_continue);
+		clone->copyProperties(this);
+		return clone;
 	}
 
 	LoopSkip(bool isContinue);

--- a/include/orange/NegativeExpr.h
+++ b/include/orange/NegativeExpr.h
@@ -21,12 +21,14 @@ public:
 	virtual Value* Codegen();
 
 	virtual ASTNode* clone() {
-		return new NegativeExpr((Expression*)m_expr->clone());
+		auto clone = new NegativeExpr((Expression*)m_expr->clone());
+		clone->copyProperties(this);
+		return clone;
 	}
 
 	virtual std::string string();
 
-	virtual OrangeTy* getType();
+	virtual void resolve();
 
 	virtual bool isSigned() { return true; }
 

--- a/include/orange/ReturnStmt.h
+++ b/include/orange/ReturnStmt.h
@@ -35,6 +35,8 @@ public:
 			return "return";
 	}
 
+	Expression* expr() const { return m_expr; }
+
 	ReturnStmt() {}
 	ReturnStmt(Expression* expr) : m_expr(expr) { addChild("m_expr", m_expr); }
 }; 

--- a/include/orange/ReturnStmt.h
+++ b/include/orange/ReturnStmt.h
@@ -23,10 +23,9 @@ public:
 
 	virtual ASTNode* clone() {
 		ReturnStmt* cloned = m_expr ? new ReturnStmt((Expression *)m_expr->clone()) : new ReturnStmt();
+		cloned->copyProperties(this);
 		return cloned; 
 	}
-
-	virtual OrangeTy* getType();
 
 	virtual std::string string() {
 		if (m_expr)
@@ -34,6 +33,8 @@ public:
 		else 
 			return "return";
 	}
+
+	virtual void resolve();
 
 	Expression* expr() const { return m_expr; }
 

--- a/include/orange/SymTable.h
+++ b/include/orange/SymTable.h
@@ -89,11 +89,19 @@ public:
 	bool create(std::string name, ASTNode* node);
 
 	/**
+	 * Gets an ASTNode in this table by name, if it exists.
+	 * @param name The name of the ASTNode to get. 
+	 * @return The ASTNode in this symbol table.
+	 */
+	ASTNode* get(std::string name);
+
+	/**
 	 * Find a ASTNode in this tree by name, if it exists.
+	 * Looks up the list of parents.
 	 *
 	 * @param name The name of the ASTNode to find.
 	 *
-	 * @return The ASTNode in this symbol table.
+	 * @return The ASTNode in this symbol table tree.
 	 */
 	ASTNode* find(std::string name, bool includeInactive = false);
 
@@ -103,7 +111,7 @@ public:
 	 *
 	 * @param name The name of the ASTNode to find.
 	 *
-	 * @return The ASTNode in this symbol table.
+	 * @return The ASTNode in this symbol table tree.
 	 */
 	ASTNode* findFromAny(std::string name, bool includeInactive = false);
 

--- a/include/orange/SymTable.h
+++ b/include/orange/SymTable.h
@@ -13,14 +13,6 @@
 
 class SymTable {
 private:
-	struct SymObj {
-		ASTNode* node = nullptr;  
-		bool active = false;
-
-		SymObj() {}
-		SymObj(ASTNode* node, bool active) : node(node), active(active) {}
-	};
-
 	SymTable* m_parent = nullptr; 
 
 	/** 
@@ -41,11 +33,13 @@ private:
 	 */
 	ASTNode *m_structure = nullptr;
 
-	std::map<std::string, SymObj *> m_objs;
+	std::map<std::string, ASTNode *> m_objs;
 
 	int m_ID = 0; 
 
 	bool m_root = false;
+
+	bool nodeValidFrom(ASTNode* node, ASTNode* from);
 public:
 	/**
 	 * Gets the parent symbol table of this one. 
@@ -103,7 +97,7 @@ public:
 	 *
 	 * @return The ASTNode in this symbol table tree.
 	 */
-	ASTNode* find(std::string name, bool includeInactive = false);
+	ASTNode* find(std::string name, ASTNode* from);
 
 	/** 
 	 * Finds an ASTNode in this tree by name, if it exists.
@@ -113,19 +107,7 @@ public:
 	 *
 	 * @return The ASTNode in this symbol table tree.
 	 */
-	ASTNode* findFromAny(std::string name, bool includeInactive = false);
-
-	/** 
-	 * Activates an object in the symbol table by name and node.
-	 * Both name and node must match for an object to be activated.
-	 * @return True if an object was activated, false otherwise.
-	 */
-	bool activate(std::string name, ASTNode* node);
-
-	/** 
-	 * Resets all objects to being inactive.
-	 */
-	void reset();
+	ASTNode* findFromAny(std::string name, ASTNode* from);
 
 	/**
 	 * Finds the closest ASTNode of a certain class.

--- a/include/orange/TernaryExpr.h
+++ b/include/orange/TernaryExpr.h
@@ -25,8 +25,6 @@ public:
 
 	virtual ASTNode* clone();
 
-	virtual OrangeTy* getType();
-
 	virtual void resolve();
 
 	virtual bool isSigned();

--- a/include/orange/VarExpr.h
+++ b/include/orange/VarExpr.h
@@ -52,8 +52,6 @@ public:
 
 	virtual void setType(OrangeTy* type);
 
-	virtual Value* getValue();
-
 	virtual void resolve();
 
 	virtual bool isSigned() { return getType()->isSigned(); }

--- a/include/orange/VarExpr.h
+++ b/include/orange/VarExpr.h
@@ -67,7 +67,7 @@ public:
 	/**
 	 * Tries to create this variable in the symbol table.
 	 */
-	virtual void create(bool throwError = true); 
+	virtual void create(); 
 
 	/**
 	 * Returns whether or not this variable exists in a parent.

--- a/include/orange/VarExpr.h
+++ b/include/orange/VarExpr.h
@@ -50,8 +50,6 @@ public:
 
 	virtual std::string string();
 
-	virtual OrangeTy* getType();
-
 	virtual void setType(OrangeTy* type);
 
 	virtual Value* getValue();

--- a/include/orange/VarExpr.h
+++ b/include/orange/VarExpr.h
@@ -63,7 +63,7 @@ public:
 	/**
 	 * Tries to create this variable in the symbol table.
 	 */
-	virtual void create(); 
+	virtual void initialize(); 
 
 	/**
 	 * Returns whether or not this variable exists in a parent.

--- a/include/orange/VarExpr.h
+++ b/include/orange/VarExpr.h
@@ -44,6 +44,7 @@ public:
 		ret->m_locked = m_locked; 
 		ret->m_signed = m_signed; 
 		ret->m_type = m_type;
+		ret->copyProperties(this);
 		return ret;
 	}
 

--- a/include/orange/types/OrangeTy.h
+++ b/include/orange/types/OrangeTy.h
@@ -50,6 +50,8 @@ public:
 
 	static OrangeTy* get(std::string str);
 
+	virtual void resolve() {}
+
 	////
 	// Type comparison section 
 	////

--- a/include/orange/types/VariadicArrayTy.h
+++ b/include/orange/types/VariadicArrayTy.h
@@ -32,6 +32,8 @@ public:
 
 	virtual Expression* getVariadicArrayElement() { return m_count; }
 
+	virtual void resolve();
+
 	virtual OrangeTy* getBaseType() { return m_internal_ty->getBaseType(); }
 
 	static VariadicArrayTy* get(OrangeTy* internalTy, Expression* count);

--- a/test/README.md
+++ b/test/README.md
@@ -11,6 +11,7 @@ The tests in each subdirectory have been arranged to have the following preceden
 ```
 basic/
 functions/
+recursion/
 if/
 variables/
 loops/

--- a/test/recursion/recursion_1.or
+++ b/test/recursion/recursion_1.or
@@ -1,0 +1,6 @@
+def recurse(var n) 
+	return recurse(n + 1) if n < 2
+	return n 
+end 
+
+return recurse(1) - 2

--- a/test/recursion/recursion_2.or
+++ b/test/recursion/recursion_2.or
@@ -1,0 +1,9 @@
+def recurse(var n) 
+	if n < 2
+		return recurse(n + 1) 
+	end 
+	
+	return n 
+end 
+
+return recurse(1) - 2

--- a/test/recursion/recursion_3.or
+++ b/test/recursion/recursion_3.or
@@ -1,0 +1,10 @@
+def recurse(var n) 
+	if n < 2
+		var num = recurse(n + 1) 
+		return num
+	end 
+	
+	return n 
+end 
+
+return recurse(1) - 2

--- a/test/recursion/recursion_4.or
+++ b/test/recursion/recursion_4.or
@@ -1,0 +1,10 @@
+def recurse(var n) 
+	if n < 2
+		var num = recurse(n + 1) 
+		return num
+	else 
+		return n 
+	end 
+end 
+
+return recurse(1) - 2

--- a/test/recursion/recursion_5.or
+++ b/test/recursion/recursion_5.or
@@ -1,0 +1,6 @@
+def recurse(var n) 
+	return n if n >= 2 
+	return recurse(n + 1)
+end 
+
+return recurse(1) - 2

--- a/test/recursion/recursion_6.or
+++ b/test/recursion/recursion_6.or
@@ -1,0 +1,9 @@
+def recurse(var n) 
+	if n >= 2
+		return n 
+	end  
+	
+	return recurse(n + 1)
+end 
+
+return recurse(1) - 2

--- a/test/recursion/recursion_7.or
+++ b/test/recursion/recursion_7.or
@@ -1,0 +1,9 @@
+def recurse(var n) 
+	if n >= 2
+		return n 
+	else 
+		return recurse(n + 1)
+	end 
+end 
+
+return recurse(1) - 2

--- a/tools/orange/AST.cc
+++ b/tools/orange/AST.cc
@@ -8,7 +8,18 @@
 
 #include <orange/AST.h>
 #include <orange/generator.h>
+#include <orange/Block.h>
 
 FunctionStmt* ASTNode::getContainingFunction() {
 	return (FunctionStmt*)GE::runner()->symtab()->findStructure("FunctionStmt");
+}
+
+Block* ASTNode::parentBlock() const {
+	auto parentPtr = m_parent; 
+
+	while (parentPtr != nullptr && dynamic_cast<Block *>(parentPtr) == nullptr) {
+		parentPtr = parentPtr->m_parent; 
+	}
+
+	return (Block *)parentPtr; 
 }

--- a/tools/orange/AST.cc
+++ b/tools/orange/AST.cc
@@ -24,7 +24,7 @@ ASTNode* ASTNode::root() const {
 
 std::string ASTNode::dump() {
 	std::stringstream ss; 
-	ss << "[" << getClass() << "] " << this << std::endl;
+	ss << "[" << getClass() << "] " << m_ID << " " << this << std::endl;
 
 	for (auto child : m_children) {
 		std::vector<std::string> lines = split(child->dump(), '\n');
@@ -59,4 +59,10 @@ Block* ASTNode::parentBlock() const {
 	}
 
 	return (Block *)parentPtr; 
+}
+
+unsigned long lastID = 0;
+
+ASTNode::ASTNode() {
+	m_ID = lastID++;
 }

--- a/tools/orange/AST.cc
+++ b/tools/orange/AST.cc
@@ -9,6 +9,43 @@
 #include <orange/AST.h>
 #include <orange/generator.h>
 #include <orange/Block.h>
+#include <sstream>
+#include <helper/string.h>
+
+ASTNode* ASTNode::root() const {
+	auto ptr = m_parent; 
+
+	while (ptr->m_parent != nullptr) {
+		ptr = ptr->m_parent;
+	}
+
+	return ptr; 
+}	
+
+std::string ASTNode::dump() {
+	std::stringstream ss; 
+	ss << "[" << getClass() << "] " << this << std::endl;
+
+	for (auto child : m_children) {
+		std::vector<std::string> lines = split(child->dump(), '\n');
+		for (std::string line : lines) {
+			ss << "\t" << line << std::endl;
+		}
+	}
+
+	return ss.str();
+}
+
+bool ASTNode::contains(ASTNode* node) {
+	if (this == node) return true; 
+
+	for (auto child : m_children) {
+		if (child == node) return true; 
+		if (child->contains(node)) return true; 
+	}
+
+	return false;
+}
 
 FunctionStmt* ASTNode::getContainingFunction() {
 	return (FunctionStmt*)GE::runner()->symtab()->findStructure("FunctionStmt");

--- a/tools/orange/AST.cc
+++ b/tools/orange/AST.cc
@@ -63,6 +63,26 @@ Block* ASTNode::parentBlock() const {
 
 unsigned long lastID = 0;
 
+void ASTNode::addChild(ASTNode* child) {
+	if (child == nullptr) return; 
+	child->setParent(this);
+	m_children.push_back(child);
+}
+
+void ASTNode::addChild(std::string tag, ASTNode* child) {
+	if (child == nullptr) return;
+	child->setParent(this);
+	m_children.push_back(child);
+}
+
+void ASTNode::newID() {
+	m_ID = lastID++;
+
+	for (auto child : m_children) {
+		child->newID();
+	}
+}
+
 ASTNode::ASTNode() {
 	m_ID = lastID++;
 }

--- a/tools/orange/AST.cc
+++ b/tools/orange/AST.cc
@@ -26,6 +26,10 @@ std::string ASTNode::dump() {
 	std::stringstream ss; 
 	ss << "[" << getClass() << "] " << m_ID << " " << this << std::endl;
 
+	if (m_dependency) {
+		ss << "\t@ [" << m_dependency->getClass() << "] " << m_dependency->m_ID << " " << m_dependency << std::endl;
+	}
+
 	for (auto child : m_children) {
 		std::vector<std::string> lines = split(child->dump(), '\n');
 		for (std::string line : lines) {

--- a/tools/orange/AddressOfExpr.cc
+++ b/tools/orange/AddressOfExpr.cc
@@ -27,6 +27,9 @@ ASTNode* AddressOfExpr::clone() {
 void AddressOfExpr::resolve() { 
 	ASTNode::resolve();
 
+	if (m_resolved) return; 
+	m_resolved = true;
+
 	if (m_expr->returnsPtr() == false) {
 		throw CompilerMessage(*m_expr, "can not get the address of this expression"); 
 	}

--- a/tools/orange/AddressOfExpr.cc
+++ b/tools/orange/AddressOfExpr.cc
@@ -19,11 +19,9 @@ Value* AddressOfExpr::Codegen() {
 }
 
 ASTNode* AddressOfExpr::clone() {
-	return new AddressOfExpr((Expression *)m_expr->clone());
-}
-
-OrangeTy* AddressOfExpr::getType() {
-	return m_expr->getType()->getPointerTo();
+	auto clone = new AddressOfExpr((Expression *)m_expr->clone());
+	clone->copyProperties(this);
+	return clone;
 }
 
 void AddressOfExpr::resolve() { 
@@ -32,6 +30,8 @@ void AddressOfExpr::resolve() {
 	if (m_expr->returnsPtr() == false) {
 		throw CompilerMessage(*m_expr, "can not get the address of this expression"); 
 	}
+
+	m_type = m_expr->getType()->getPointerTo();
 }
 
 AddressOfExpr::AddressOfExpr(Expression* expr) {

--- a/tools/orange/AnyID.cc
+++ b/tools/orange/AnyID.cc
@@ -28,7 +28,9 @@ Value* AnyID::getValue() {
 }
 
 ASTNode* AnyID::clone() {
-	return new AnyID(m_name);
+	auto clone = new AnyID(m_name);
+	clone->copyProperties(this);
+	return clone;
 }
 
 std::string AnyID::string() {
@@ -66,16 +68,13 @@ void AnyID::resolve() {
 
 	if (node != nullptr && node->getClass() != "VarExpr") {
 		m_any_expr = (Expression *)node; 
+		addChild("m_any_expr", m_any_expr);
 	} else {
 		// Otherwise, we have to create something it should default to a VarExpr.
 		m_any_expr = new VarExpr(m_name);
-  	m_any_expr->resolve();
+		addChild("m_any_expr", m_any_expr);
+		ASTNode::resolve();
 	}
-
-	// We essentially transform into our any_expr here, so set its parent to our parent.
-	addChild("m_any_expr", m_any_expr);
-
-	// Resolve it. If the variable already exists, this probably won't do anything.
 }
 
 bool AnyID::isSigned() {
@@ -98,7 +97,9 @@ Expression* AnyID::expression() {
 
 void AnyID::newVarExpr() {
 	m_any_expr = new VarExpr(m_name);
-	m_any_expr->resolve();
+
+	addChild("m_any_expr", m_any_expr);
+	ASTNode::resolve();
 }
 
 AnyID::AnyID(std::string name) {

--- a/tools/orange/AnyID.cc
+++ b/tools/orange/AnyID.cc
@@ -53,6 +53,23 @@ OrangeTy* AnyID::getType() {
 	return m_any_expr->getType();
 }
 
+void AnyID::mapDependencies() {
+	SymTable* tab = GE::runner()->topBlock()->symtab();
+	ASTNode* node = tab->find(m_name, this);
+
+	if (node != nullptr && node->getClass() == "VarExpr") {
+		auto parent = node->parent();
+
+		// AnyID's depend on the parent of where a variable is stored 
+		// (this will be the ExplicitDeclStmt).
+		if (parent->getClass() == "ExplicitDeclStmt") {
+			m_dependency = parent;
+		}
+	} else if (node == nullptr) {
+		throw CompilerMessage(*this, m_name + " doesn't exist in this scope.");
+	}
+}
+
 void AnyID::resolve() {
 	if (m_resolved) return; 
 	m_resolved = true;

--- a/tools/orange/ArrayAccess.cc
+++ b/tools/orange/ArrayAccess.cc
@@ -46,7 +46,9 @@ Value* ArrayAccess::Codegen() {
 }
 
 ASTNode* ArrayAccess::clone() {
-	return new ArrayAccess((Expression *)m_variable->clone(), (Expression *)m_idx->clone());
+	auto clone = new ArrayAccess((Expression *)m_variable->clone(), (Expression *)m_idx->clone());
+	clone->copyProperties(this);
+	return clone;
 }
 
 std::string ArrayAccess::string() {
@@ -56,22 +58,20 @@ std::string ArrayAccess::string() {
 	return ss.str();
 }
 
-OrangeTy* ArrayAccess::getType() {
-	OrangeTy* varType = m_variable->getType();
-
-	if (varType->isConstantArray() || varType->isVariadicArray()) {
-		return varType->getArrayElementType();
-	} else {
-		return varType->getPointerElementType();
-	}
-}
-
 void ArrayAccess::resolve() {
 	ASTNode::resolve();
 
 	// m_variable must be an array or pointer! 
 	if (m_variable->getType()->isArrayTy() == false && m_variable->getType()->isPointerTy() == false) {
 		throw CompilerMessage(*m_variable, "variable must be an array!");
+	}
+
+	m_type = m_variable->getType();
+
+	if (m_type->isConstantArray() || m_type->isVariadicArray()) {
+		m_type = m_type->getArrayElementType();
+	} else {
+		m_type = m_type->getPointerElementType();
 	}
 }
 

--- a/tools/orange/ArrayAccess.cc
+++ b/tools/orange/ArrayAccess.cc
@@ -61,6 +61,9 @@ std::string ArrayAccess::string() {
 void ArrayAccess::resolve() {
 	ASTNode::resolve();
 
+	if (m_resolved) return; 
+	m_resolved = true;
+
 	// m_variable must be an array or pointer! 
 	if (m_variable->getType()->isArrayTy() == false && m_variable->getType()->isPointerTy() == false) {
 		throw CompilerMessage(*m_variable, "variable must be an array!");

--- a/tools/orange/ArrayExpr.cc
+++ b/tools/orange/ArrayExpr.cc
@@ -94,13 +94,18 @@ ASTNode* ArrayExpr::clone() {
 		cloned_elements.push_back((Expression *)element->clone());
 	}
 
-	return new ArrayExpr(cloned_elements);
+	auto clone = new ArrayExpr(cloned_elements);
+	clone->copyProperties(this);
+	return clone;
 }
 
-OrangeTy* ArrayExpr::getType() {
+void ArrayExpr::resolve() {
+	ASTNode::resolve();
+
 	// If we don't have any elements, we're an int*. 
 	if (m_elements.size() == 0) {
-		return IntTy::getSigned(64)->getPointerTo();
+		m_type = IntTy::getSigned(64)->getPointerTo();
+		return;
 	}
 	
 	// First, we need to find the highest precedence type from all of the elements.
@@ -133,13 +138,11 @@ OrangeTy* ArrayExpr::getType() {
 	}	
 
 	// Now that we know the stack of elements, we can create our type.
-	OrangeTy* ret = highestType;
+	m_type = highestType;
 
 	for (auto i = elementStack.rbegin(); i < elementStack.rend(); i++) {
-		ret = ArrayTy::get(ret, *i);
+		m_type = ArrayTy::get(m_type, *i);
 	}
-
-	return ret; 
 }
 
 bool ArrayExpr::isConstant() {

--- a/tools/orange/ArrayExpr.cc
+++ b/tools/orange/ArrayExpr.cc
@@ -102,6 +102,9 @@ ASTNode* ArrayExpr::clone() {
 void ArrayExpr::resolve() {
 	ASTNode::resolve();
 
+	if (m_resolved) return; 
+	m_resolved = true;
+
 	// If we don't have any elements, we're an int*. 
 	if (m_elements.size() == 0) {
 		m_type = IntTy::getSigned(64)->getPointerTo();

--- a/tools/orange/BinOpExpr.cc
+++ b/tools/orange/BinOpExpr.cc
@@ -329,28 +329,6 @@ std::string BinOpExpr::string() {
 	return ss.str();
 }
 
-OrangeTy* BinOpExpr::getType() {
-	if (IsAssignOp(m_op)) {
-		OrangeTy* t = m_LHS->getType(); 
-		return t->isVoidTy() ? m_RHS->getType() : t; 
-	} 
-
-	OrangeTy *lType = m_LHS->getType();
-	OrangeTy *rType = m_RHS->getType();
-
-	if (lType->isVoidTy()) {
-		throw CompilerMessage(*m_LHS, m_LHS->string() + " does not exist!");
-	} else if (rType->isVoidTy()) {
-		throw CompilerMessage(*m_RHS, m_RHS->string() + " does not exist!");
-	}
-
-	if (IsCompareOp(m_op)) {
-		return IntTy::getUnsigned(1);
-	} else {
-		return CastingEngine::GetFittingType(lType, rType);
-	}
-}
-
 void BinOpExpr::resolve() {
 	ASTNode::resolve();
 
@@ -371,6 +349,29 @@ void BinOpExpr::resolve() {
 		if (var->isLocked() == false && CastingEngine::GetFittingType(var->getType(), m_RHS->getType()) == m_RHS->getType()) {
 			var->setType(m_RHS->getType());
 		}
+	}
+
+	// 
+	// Determine type 
+	//
+	if (IsAssignOp(m_op)) {
+		OrangeTy* t = m_LHS->getType(); 
+		m_type = t->isVoidTy() ? m_RHS->getType() : t; 
+	} else {
+		OrangeTy *lType = m_LHS->getType();
+		OrangeTy *rType = m_RHS->getType();
+
+		if (lType->isVoidTy()) {
+			throw CompilerMessage(*m_LHS, m_LHS->string() + " does not exist!");
+		} else if (rType->isVoidTy()) {
+			throw CompilerMessage(*m_RHS, m_RHS->string() + " does not exist!");
+		}
+
+		if (IsCompareOp(m_op)) {
+			m_type = IntTy::getUnsigned(1);
+		} else {
+			m_type = CastingEngine::GetFittingType(lType, rType);
+		}		
 	}
 }
 

--- a/tools/orange/BinOpExpr.cc
+++ b/tools/orange/BinOpExpr.cc
@@ -201,7 +201,7 @@ Value* BinOpExpr::Codegen() {
 	Value* OrigRHS = RHS; 
 
 	if (m_op == "=" && LHS == nullptr) {
-		throw CompilerMessage(*m_LHS, m_LHS->string() + " doesn't exist!");
+		throw CompilerMessage(*m_LHS, m_LHS->string() + " never created in this scope.");
 	}
 
 	// Validate should never return false, since it throws an exception any time it encounters 
@@ -331,6 +331,9 @@ std::string BinOpExpr::string() {
 
 void BinOpExpr::resolve() {
 	ASTNode::resolve();
+
+	if (m_resolved) return; 
+	m_resolved = true;
 
 	if (m_op == "=" && isVarExpr(m_LHS)) {
 		// Set the type of LHS if it doesn't exist or this type has higher precedence. 

--- a/tools/orange/Block.cc
+++ b/tools/orange/Block.cc
@@ -68,12 +68,31 @@ Value* Block::Codegen() {
 	return nullptr;
 }
 
-bool Block::hasReturn() {
-	for (ASTNode *s : m_statements) {
-		if (s->getClass() == "ReturnStmt") return true; 
+// Finds a list of all return statements starting at a root 
+bool findReturn(ASTNode* root) {
+	if (root->getClass() == "ReturnStmt") {
+		return true;
+	}
+
+	for (auto stmt : root->children()) {
+		// Do not go into nested functions.
+		if (stmt->getClass() == "FunctionStmt") continue;
+		if (findReturn(stmt) == true) return true;
 	}
 
 	return false;
+}
+
+bool Block::hasReturn() {
+	for (auto stmt : m_statements) {
+		if (stmt->getClass() == "ReturnStmt") return true;
+	}
+
+	return false;
+}
+
+bool Block::hasReturnNested() {
+	return findReturn(this);
 }
 
 bool Block::hasJump() {

--- a/tools/orange/Block.cc
+++ b/tools/orange/Block.cc
@@ -183,6 +183,27 @@ std::string Block::string() {
 	return ss.str();
 }
 
+void Block::mapDependencies() {
+	Runner* curRunner = GE::runner();
+
+	GE::runner()->pushBlock(this);
+
+	// Resolve all of our statements.
+	for (auto stmt : m_statements) {
+		try {
+			stmt->mapDependencies();
+		} catch (CompilerMessage& e) {
+			curRunner->log(e);
+		} catch (std::runtime_error& e) {
+			CodeLocation loc = stmt->location();
+			CompilerMessage msg(ERROR, e.what(), curRunner->pathname(), loc.row_begin, loc.row_end, loc.col_begin, loc.col_end);
+			curRunner->log(msg);
+		}
+	}
+
+	GE::runner()->popBlock();		
+}
+
 void Block::initialize() {
 	Runner* curRunner = GE::runner();
 

--- a/tools/orange/Block.cc
+++ b/tools/orange/Block.cc
@@ -183,6 +183,27 @@ std::string Block::string() {
 	return ss.str();
 }
 
+void Block::initialize() {
+	Runner* curRunner = GE::runner();
+
+	GE::runner()->pushBlock(this);
+
+	// Resolve all of our statements.
+	for (auto stmt : m_statements) {
+		try {
+			stmt->initialize();
+		} catch (CompilerMessage& e) {
+			curRunner->log(e);
+		} catch (std::runtime_error& e) {
+			CodeLocation loc = stmt->location();
+			CompilerMessage msg(ERROR, e.what(), curRunner->pathname(), loc.row_begin, loc.row_end, loc.col_begin, loc.col_end);
+			curRunner->log(msg);
+		}
+	}
+
+	GE::runner()->popBlock();	
+}
+
 void Block::resolve() {
 	Runner* curRunner = GE::runner();
 

--- a/tools/orange/Block.cc
+++ b/tools/orange/Block.cc
@@ -166,6 +166,8 @@ ASTNode* Block::clone() {
 			}
 		}
 	}
+
+	clonedBlock->copyProperties(this);	
 	return clonedBlock;
 }
 

--- a/tools/orange/Block.cc
+++ b/tools/orange/Block.cc
@@ -62,8 +62,6 @@ Value* Block::Codegen() {
 
 	GE::runner()->pushBlock(this);
 
-	m_symtab->reset();
-
 	generateStatements();
 
 	GE::runner()->popBlock();

--- a/tools/orange/CastExpr.cc
+++ b/tools/orange/CastExpr.cc
@@ -29,11 +29,9 @@ Value* CastExpr::Codegen() {
 }
 
 ASTNode* CastExpr::clone() {
-	return new CastExpr(m_type, (Expression *)m_expr->clone());
-}
-
-OrangeTy* CastExpr::getType() { 
-	return m_type; 
+	auto clone = new CastExpr(m_type, (Expression *)m_expr->clone());
+	clone->copyProperties(this);
+	return clone;
 }
 
 bool CastExpr::isSigned() { 

--- a/tools/orange/CommaStmt.cc
+++ b/tools/orange/CommaStmt.cc
@@ -17,7 +17,10 @@ Value* CommaStmt::Codegen() {
 ASTNode* CommaStmt::clone() {
 	std::vector<Expression*> clonedExprs;
 	for (auto expr : m_exprs) clonedExprs.push_back((Expression*)expr->clone());
-	return new CommaStmt(clonedExprs);
+		
+	auto clone = new CommaStmt(clonedExprs);
+	clone->copyProperties(this);
+	return clone;
 }
 
 std::string CommaStmt::string() {

--- a/tools/orange/CondBlock.cc
+++ b/tools/orange/CondBlock.cc
@@ -44,6 +44,7 @@ ASTNode* CondBlock::clone() {
 		}
 	}
 
+	clonedBlock->copyProperties(this);
 	return clonedBlock;
 }
 

--- a/tools/orange/CondBlock.cc
+++ b/tools/orange/CondBlock.cc
@@ -51,7 +51,7 @@ ASTNode* CondBlock::clone() {
 
 void CondBlock::resolve() {
 	pushBlock();
-	ASTNode::resolve();
+	m_condition->resolve();
 	popBlock();
 	
 	Block::resolve();

--- a/tools/orange/DerefExpr.cc
+++ b/tools/orange/DerefExpr.cc
@@ -37,6 +37,9 @@ ASTNode* DerefExpr::clone() {
 void DerefExpr::resolve() {
 	ASTNode::resolve();
 
+	if (m_resolved) return; 
+	m_resolved = true;
+
 	m_type = m_expr->getType();
 
 	if (m_type->isPointerTy()) {

--- a/tools/orange/DerefExpr.cc
+++ b/tools/orange/DerefExpr.cc
@@ -29,22 +29,23 @@ Value* DerefExpr::Codegen() {
 }
 
 ASTNode* DerefExpr::clone() {
-	return new DerefExpr((Expression*)m_expr->clone());
+	auto clone = new DerefExpr((Expression*)m_expr->clone());
+	clone->copyProperties(this);
+	return clone;
 }
 
-OrangeTy* DerefExpr::getType() {
-	OrangeTy* exprType = m_expr->getType();
+void DerefExpr::resolve() {
+	ASTNode::resolve();
 
-	if (exprType->isPointerTy()) {
-		return m_expr->getType()->getPointerElementType();
-	} else if (exprType->isArrayTy()) {
-		return m_expr->getType()->getArrayElementType();
+	m_type = m_expr->getType();
+
+	if (m_type->isPointerTy()) {
+		m_type = m_type->getPointerElementType();
+	} else if (m_type->isArrayTy()) {
+		m_type = m_type->getArrayElementType();
 	} else {
 		throw CompilerMessage(*m_expr, "expression is not a pointer");
 	}
-
-	// should never reach this line.
-	return nullptr; 
 }
 
 bool DerefExpr::returnsPtr() {

--- a/tools/orange/DotExpr.cc
+++ b/tools/orange/DotExpr.cc
@@ -40,6 +40,9 @@ ASTNode* DotExpr::clone() {
 void DotExpr::resolve() {
 	ASTNode::resolve();
 
+	if (m_resolved) return; 
+	m_resolved = true;
+
 	if (m_LHS->expression()->getClass() != "EnumStmt") {
 		throw CompilerMessage(*this, ". only supports enums!");
 	}

--- a/tools/orange/DotExpr.cc
+++ b/tools/orange/DotExpr.cc
@@ -32,17 +32,9 @@ Value* DotExpr::Codegen() {
 }
 
 ASTNode* DotExpr::clone() {
-	return new DotExpr((AnyID*)m_LHS->clone(), m_RHS);
-}
-
-OrangeTy* DotExpr::getType() {
-	if (m_obj->getClass() == "EnumStmt") {
-		EnumStmt* enumStmt = (EnumStmt*)m_obj;
-		return enumStmt->getType();
-	}
-
-	throw std::runtime_error("DotExpr::getType(): object is not an enum!");
-	return nullptr;
+	auto clone = new DotExpr((AnyID*)m_LHS->clone(), m_RHS);
+	clone->copyProperties(this);
+	return clone;
 }
 
 void DotExpr::resolve() {
@@ -60,6 +52,7 @@ void DotExpr::resolve() {
 	}
 
 	m_obj = enumStmt;
+	m_type = enumStmt->getType();
 }
 
 bool DotExpr::isSigned() {

--- a/tools/orange/EnumStmt.cc
+++ b/tools/orange/EnumStmt.cc
@@ -33,6 +33,17 @@ std::string EnumStmt::string() {
 	return ss.str();
 }
 
+void EnumStmt::initialize() {
+	ASTNode::initialize();
+	
+	// Now that everything is the same type, let's add the EnumStmt to the symbol table.
+	SymTable* tab = GE::runner()->topBlock()->symtab();
+
+	if (tab->create(m_name, this) == false) {
+		throw CompilerMessage(*this, "Something named " + m_name + " already exists!");
+	}
+}
+
 void EnumStmt::resolve() {
 	if (m_resolved) return; 
 	m_resolved = true;
@@ -56,13 +67,6 @@ void EnumStmt::resolve() {
 
 		delete pair.value; // Delete our old value.
 		pair.value = factory.produce();
-	}
-
-	// Now that everything is the same type, let's add the EnumStmt to the symbol table.
-	SymTable* tab = GE::runner()->topBlock()->symtab();
-
-	if (tab->create(m_name, this) == false) {
-		throw CompilerMessage(*this, "Something named " + m_name + " already exists!");
 	}
 }
 

--- a/tools/orange/EnumStmt.cc
+++ b/tools/orange/EnumStmt.cc
@@ -10,9 +10,6 @@
 #include <orange/generator.h>
 
 Value* EnumStmt::Codegen() {
-	// Reactivate us in the symbol table.
-	GE::runner()->topBlock()->symtab()->activate(m_name, this);
-
 	return nullptr;
 }
 
@@ -37,6 +34,9 @@ std::string EnumStmt::string() {
 }
 
 void EnumStmt::resolve() {
+	if (m_resolved) return; 
+	m_resolved = true;
+
 	if (m_enums.size() == 0) {
 		m_type = VoidTy::get();
 	} else {
@@ -64,9 +64,6 @@ void EnumStmt::resolve() {
 	if (tab->create(m_name, this) == false) {
 		throw CompilerMessage(*this, "Something named " + m_name + " already exists!");
 	}
-
-
-
 }
 
 void EnumStmt::addEnum(std::string name) {

--- a/tools/orange/EnumStmt.cc
+++ b/tools/orange/EnumStmt.cc
@@ -37,9 +37,17 @@ std::string EnumStmt::string() {
 }
 
 void EnumStmt::resolve() {
-	// We have to do some morphing here; first; determine the highest type.
-	// We can use getType because it will calculate it until the type is cached.
-	m_type = getType();
+	if (m_enums.size() == 0) {
+		m_type = VoidTy::get();
+	} else {
+		// We need to determine the highest precedence type and then
+		// change the other enums to use that type.
+		m_type = m_enums[0].value->getType();
+
+		for (unsigned int i = 1; i < m_enums.size(); i++) {
+			m_type = CastingEngine::GetFittingType(m_type, m_enums[i].value->getType());
+		}
+	}
 
 	for (auto& pair : m_enums) {
 		ValFactory factory;
@@ -57,17 +65,7 @@ void EnumStmt::resolve() {
 		throw CompilerMessage(*this, "Something named " + m_name + " already exists!");
 	}
 
-	if (m_enums.size() == 0) {
-		m_type = VoidTy::get();
-	} else {
-		// We need to determine the highest precedence type and then
-		// change the other enums to use that type.
-		m_type = m_enums[0].value->getType();
 
-		for (unsigned int i = 1; i < m_enums.size(); i++) {
-			m_type = CastingEngine::GetFittingType(m_type, m_enums[i].value->getType());
-		}
-	}
 
 }
 

--- a/tools/orange/EnumStmt.cc
+++ b/tools/orange/EnumStmt.cc
@@ -19,27 +19,8 @@ Value* EnumStmt::Codegen() {
 ASTNode* EnumStmt::clone() {
 	EnumStmt* clone = new EnumStmt(m_name);
 	clone->m_enums = m_enums;
+	clone->copyProperties(this);
 	return clone;
-}
-
-OrangeTy* EnumStmt::getType() {
-	if (m_type != nullptr) {
-		return m_type;
-	}
-
-	if (m_enums.size() == 0) {
-		return VoidTy::get();
-	}
-
-	// We need to determine the highest precedence type and then
-	// change the other enums to use that type.
-	OrangeTy* highestType = m_enums[0].value->getType();
-
-	for (unsigned int i = 1; i < m_enums.size(); i++) {
-		highestType = CastingEngine::GetFittingType(highestType, m_enums[i].value->getType());
-	}
-
-	return highestType;
 }
 
 std::string EnumStmt::string() {
@@ -75,6 +56,19 @@ void EnumStmt::resolve() {
 	if (tab->create(m_name, this) == false) {
 		throw CompilerMessage(*this, "Something named " + m_name + " already exists!");
 	}
+
+	if (m_enums.size() == 0) {
+		m_type = VoidTy::get();
+	} else {
+		// We need to determine the highest precedence type and then
+		// change the other enums to use that type.
+		m_type = m_enums[0].value->getType();
+
+		for (unsigned int i = 1; i < m_enums.size(); i++) {
+			m_type = CastingEngine::GetFittingType(m_type, m_enums[i].value->getType());
+		}
+	}
+
 }
 
 void EnumStmt::addEnum(std::string name) {

--- a/tools/orange/ExplicitDeclStmt.cc
+++ b/tools/orange/ExplicitDeclStmt.cc
@@ -69,15 +69,16 @@ ASTNode* ExplicitDeclStmt::clone() {
 		extraClones.push_back(DeclPair(pair.var->name(), (Expression *)pair.val->clone()));
 	}
 
-	if (m_expr) {
-		return new ExplicitDeclStmt((VarExpr*)m_var->clone(), (Expression*)m_expr->clone(), extraClones);
-	} else {
-		return new ExplicitDeclStmt((VarExpr*)m_var->clone(), extraClones);
-	}
-}
+	ASTNode* clone = nullptr; 
 
-OrangeTy* ExplicitDeclStmt::getType() { 
-	return m_var->getType(); 
+	if (m_expr) {
+		clone = new ExplicitDeclStmt((VarExpr*)m_var->clone(), (Expression*)m_expr->clone(), extraClones);
+	} else {
+		clone = new ExplicitDeclStmt((VarExpr*)m_var->clone(), extraClones);
+	}
+
+	clone->copyProperties(this);
+	return clone;
 }
 
 bool ExplicitDeclStmt::isSigned() {
@@ -117,6 +118,8 @@ void ExplicitDeclStmt::resolve() {
 			throw CompilerMessage(*pair.var, "Variable-sized arrays may not be initialized");
 		}
 	}
+
+	m_type = m_var->getType();
 }
 
 std::string ExplicitDeclStmt::string() {

--- a/tools/orange/ExplicitDeclStmt.cc
+++ b/tools/orange/ExplicitDeclStmt.cc
@@ -91,7 +91,7 @@ void ExplicitDeclStmt::resolve() {
 	if (m_resolved) return; 
 	m_resolved = true;
 
-	m_var->create();
+	//m_var->create();
 
 	if (m_var->getType()->isVoidTy()) {
 		throw CompilerMessage(*m_var, "keyword void cannot be used to create a variable");
@@ -109,7 +109,7 @@ void ExplicitDeclStmt::resolve() {
 	}
 
 	for (auto pair : m_extras) {
-		pair.var->create();
+		//pair.var->create();
 		pair.var->getType()->resolve();
 		
 		if (pair.var->getType()->isVoidTy()) {
@@ -159,6 +159,7 @@ ExplicitDeclStmt::ExplicitDeclStmt(VarExpr* var) {
 	}
 
 	m_var = var;
+	addChild("m_var", m_var);
 }
 
 ExplicitDeclStmt::ExplicitDeclStmt(VarExpr* var, std::vector<DeclPair> extras) {
@@ -167,11 +168,20 @@ ExplicitDeclStmt::ExplicitDeclStmt(VarExpr* var, std::vector<DeclPair> extras) {
 	}
 
 	m_var = var;
+	addChild("m_var", m_var);
 
 	auto typeForExtras = m_var->getType();
 
 	for (auto pair : extras) {
-		m_extras.push_back(DeclPairInternal(new VarExpr(pair.name, typeForExtras), pair.expression));
+		auto newVar = new VarExpr(pair.name, typeForExtras); 
+
+		addChild(newVar);
+
+		if (pair.expression) {
+			addChild(pair.expression);
+		}
+
+		m_extras.push_back(DeclPairInternal(newVar, pair.expression));
 	}	
 }
 
@@ -187,6 +197,9 @@ ExplicitDeclStmt::ExplicitDeclStmt(VarExpr* var, Expression* value) {
 
 	m_var = var;
 	m_expr = value; 
+
+	addChild("m_var", m_var);
+	addChild("m_expr", m_expr);
 }
 
 ExplicitDeclStmt::ExplicitDeclStmt(VarExpr* var, Expression* value, std::vector<DeclPair> extras) {
@@ -213,7 +226,10 @@ ExplicitDeclStmt::ExplicitDeclStmt(VarExpr* var, Expression* value, std::vector<
 		auto newVar = new VarExpr(pair.name, typeForExtras); 
 
 		addChild(newVar);
-		addChild(pair.expression);
+
+		if (pair.expression) {
+			addChild(pair.expression);
+		}
 
 		m_extras.push_back(DeclPairInternal(newVar, pair.expression));
 	}

--- a/tools/orange/ExplicitDeclStmt.cc
+++ b/tools/orange/ExplicitDeclStmt.cc
@@ -91,8 +91,6 @@ void ExplicitDeclStmt::resolve() {
 	if (m_resolved) return; 
 	m_resolved = true;
 
-	//m_var->create();
-
 	if (m_var->getType()->isVoidTy()) {
 		throw CompilerMessage(*m_var, "keyword void cannot be used to create a variable");
 	}
@@ -109,7 +107,6 @@ void ExplicitDeclStmt::resolve() {
 	}
 
 	for (auto pair : m_extras) {
-		//pair.var->create();
 		pair.var->getType()->resolve();
 		
 		if (pair.var->getType()->isVoidTy()) {

--- a/tools/orange/ExplicitDeclStmt.cc
+++ b/tools/orange/ExplicitDeclStmt.cc
@@ -125,6 +125,8 @@ void ExplicitDeclStmt::resolve() {
 std::string ExplicitDeclStmt::string() {
 	std::stringstream ss; 
 
+	ss << m_type->string() << " ";
+
 	if (m_expr) {
 		ss << m_var->string() << " = " << m_expr->string();
 	} else {

--- a/tools/orange/ExplicitDeclStmt.cc
+++ b/tools/orange/ExplicitDeclStmt.cc
@@ -87,6 +87,10 @@ bool ExplicitDeclStmt::isSigned() {
 
 void ExplicitDeclStmt::resolve() {
 	ASTNode::resolve();
+
+	if (m_resolved) return; 
+	m_resolved = true;
+
 	m_var->create();
 
 	if (m_var->getType()->isVoidTy()) {
@@ -98,12 +102,15 @@ void ExplicitDeclStmt::resolve() {
 		m_var->resolve(); 
 	} 
 
+	m_var->getType()->resolve();
+
 	if (m_var->getType()->isVariadicArray() && m_expr) {
 		throw CompilerMessage(*m_var, "Variable-sized arrays may not be initialized");
 	}
 
 	for (auto pair : m_extras) {
 		pair.var->create();
+		pair.var->getType()->resolve();
 		
 		if (pair.var->getType()->isVoidTy()) {
 			throw CompilerMessage(*m_var, "keyword void cannot be used to create a variable");

--- a/tools/orange/ExternFunction.cc
+++ b/tools/orange/ExternFunction.cc
@@ -62,16 +62,18 @@ Value* ExternFunction::Codegen() {
 }
 
 void ExternFunction::initialize() {
-	// don't do anything
-}
-
-void ExternFunction::resolve() {
-	if (m_resolved) return; 
-	m_resolved = true;
-
+	// don't initialize children
+	// we don't want parameters in the symbol table
+	
 	bool added = GE::runner()->symtab()->create(m_name, this);
 	if (added == false) {
 		std::string s = "A function called " + m_name + " already exists!";
 		throw std::runtime_error(s);
 	}
+}
+
+void ExternFunction::resolve() {
+	if (m_resolved) return; 
+	m_resolved = true;
+	// do nothing 
 }

--- a/tools/orange/ExternFunction.cc
+++ b/tools/orange/ExternFunction.cc
@@ -47,8 +47,6 @@ ExternFunction::ExternFunction(OrangeTy* returnType, std::string name, ParamList
 }
 
 Value* ExternFunction::Codegen() {
-	GE::runner()->symtab()->activate(m_name, this);
-
 	std::vector<Type*> Args;
 
 	for (auto param : m_parameters) {
@@ -64,6 +62,9 @@ Value* ExternFunction::Codegen() {
 }
 
 void ExternFunction::resolve() {
+	if (m_resolved) return; 
+	m_resolved = true;
+
 	bool added = GE::runner()->symtab()->create(m_name, this);
 	if (added == false) {
 		std::string s = "A function called " + m_name + " already exists!";

--- a/tools/orange/ExternFunction.cc
+++ b/tools/orange/ExternFunction.cc
@@ -61,6 +61,10 @@ Value* ExternFunction::Codegen() {
 	return m_value; 
 }
 
+void ExternFunction::initialize() {
+	// don't do anything
+}
+
 void ExternFunction::resolve() {
 	if (m_resolved) return; 
 	m_resolved = true;

--- a/tools/orange/ExternFunction.cc
+++ b/tools/orange/ExternFunction.cc
@@ -34,7 +34,9 @@ std::string ExternFunction::string() {
 	return ss.str();
 }
 
-ExternFunction::ExternFunction(OrangeTy* returnType, std::string name, ParamList parameters) : m_type(returnType), m_name(name), m_parameters(parameters) {
+ExternFunction::ExternFunction(OrangeTy* returnType, std::string name, ParamList parameters) : m_name(name), m_parameters(parameters) {
+	m_type = returnType; 
+
 	if (returnType == nullptr) {
 		throw std::runtime_error("return type for an external function can not be null!");
 	}

--- a/tools/orange/FuncCall.cc
+++ b/tools/orange/FuncCall.cc
@@ -12,7 +12,7 @@
 Value* FuncCall::Codegen() {
 	SymTable *curTab = GE::runner()->symtab();
 	
-	FunctionStmt* function = (FunctionStmt*)curTab->findFromAny(m_name); 
+	FunctionStmt* function = (FunctionStmt*)curTab->findFromAny(m_name, this); 
 
 	if (function == nullptr) {
 		throw CompilerMessage(*this, "No function " + m_name + " found!");
@@ -103,9 +103,12 @@ std::string FuncCall::string() {
 }
 
 void FuncCall::resolve() {
+	if (m_resolved) return; 
+	m_resolved = true;
+
 	// Look for the function in the symbol table.
 	SymTable *curTab = GE::runner()->symtab();
-	ASTNode* function = curTab->findFromAny(m_name); 
+	ASTNode* function = curTab->findFromAny(m_name, this); 
 
 	if (function == nullptr) {
 		throw CompilerMessage(*this, "No function " + m_name + " found!");

--- a/tools/orange/FuncCall.cc
+++ b/tools/orange/FuncCall.cc
@@ -135,7 +135,7 @@ void FuncCall::resolve() {
 	m_type = function->getType();
 
 	if (m_type == nullptr) {
-		throw CompilerMessage(*this, "Too soon to have a recursive function; no return type determined yet.");
+		throw CompilerMessage(*this, "Ambiguous return type");
 	}
 }
 

--- a/tools/orange/FuncCall.cc
+++ b/tools/orange/FuncCall.cc
@@ -129,6 +129,8 @@ void FuncCall::resolve() {
 	if (m_resolved) return; 
 	m_resolved = true;
 
+	if (m_dependency) m_dependency->resolve();
+
 	// Look for the function in the symbol table.
 	SymTable *curTab = GE::runner()->symtab();
 	ASTNode* function = curTab->findFromAny(m_name, this); 

--- a/tools/orange/FuncCall.cc
+++ b/tools/orange/FuncCall.cc
@@ -102,6 +102,29 @@ std::string FuncCall::string() {
 	return ss.str();
 }
 
+void FuncCall::mapDependencies() {
+	ASTNode::mapDependencies();
+
+	SymTable *curTab = GE::runner()->symtab();
+	ASTNode* function = curTab->findFromAny(m_name, this); 
+
+	if (function == nullptr) {
+		throw CompilerMessage(*this, "No function " + m_name + " found!");
+	}
+
+	if ((function->getClass() != "FunctionStmt" &&
+		function->getClass() != "ExternFunction")) {
+		throw CompilerMessage(*this, m_name + " is not a function!");
+	}
+
+	// The dependency here may be a generic function. 
+	// In which case, we will not be able to know which clone 
+	// we are depending on. This is not an issue, however, since 
+	// by the time dependencies are being resolved for this function 
+	// call, the function will have already been marked as resolved. 
+	m_dependency = function; 
+}
+
 void FuncCall::resolve() {
 	if (m_resolved) return; 
 	m_resolved = true;

--- a/tools/orange/FunctionStmt.cc
+++ b/tools/orange/FunctionStmt.cc
@@ -528,3 +528,29 @@ void FunctionStmt::resolve() {
 	GE::runner()->popBlock();
 
 }
+
+std::string FunctionStmt::dump() {
+	std::stringstream ss; 
+
+	if (isGeneric()) {
+		for (auto clone : m_clones) {
+			std::vector<std::string> lines = split(clone->dump(), '\n');
+			for (std::string line : lines) {
+				ss << line << std::endl;
+			}
+		}
+
+		return ss.str();
+	}
+
+	ss << "[" << getClass() << "] " << this << std::endl;
+
+	for (auto child : m_children) {
+		std::vector<std::string> lines = split(child->dump(), '\n');
+		for (std::string line : lines) {
+			ss << "\t" << line << std::endl;
+		}
+	}
+
+	return ss.str();
+}

--- a/tools/orange/FunctionStmt.cc
+++ b/tools/orange/FunctionStmt.cc
@@ -217,6 +217,7 @@ FunctionStmt* FunctionStmt::createGenericClone(ArgList args) {
 		}
 	}
 
+	clone->initialize();
 	clone->copyProperties(this);
 	return clone;
 }
@@ -454,6 +455,19 @@ BasicBlock* FunctionStmt::createBasicBlock(std::string name) {
 	return BasicBlock::Create(GE::runner()->context(), name, llvmFunction, getBlockEnd());
 }
 
+void FunctionStmt::initialize() {
+	if (isGeneric()) return;
+
+	pushBlock();
+	
+	for (auto param : m_parameters) {
+		param->initialize(); 
+	}
+
+	Block::initialize();
+
+	popBlock();
+}
 
 void FunctionStmt::resolve() {
 	if (m_resolved) return; 
@@ -498,10 +512,6 @@ void FunctionStmt::resolve() {
 	// Push our symtab into the stack and add our parameters to the symbol table.
 	GE::runner()->pushBlock(this);
 	
-	for (auto param : m_parameters) {
-		param->create();
-	}
-
 	Block::resolve();
 
 	if (m_type_set == false) {

--- a/tools/orange/FunctionStmt.cc
+++ b/tools/orange/FunctionStmt.cc
@@ -553,7 +553,7 @@ std::string FunctionStmt::dump() {
 		return ss.str();
 	}
 
-	ss << "[" << getClass() << "] " << this << std::endl;
+	ss << "[" << getClass() << "] " << ID() << " " << this << std::endl;
 
 	for (auto child : m_children) {
 		std::vector<std::string> lines = split(child->dump(), '\n');

--- a/tools/orange/FunctionStmt.cc
+++ b/tools/orange/FunctionStmt.cc
@@ -458,23 +458,6 @@ BasicBlock* FunctionStmt::createBasicBlock(std::string name) {
 }
 
 void FunctionStmt::initialize() {
-	if (isGeneric()) return;
-
-	pushBlock();
-	
-	for (auto param : m_parameters) {
-		param->initialize(); 
-	}
-
-	Block::initialize();
-
-	popBlock();
-}
-
-void FunctionStmt::resolve() {
-	if (m_resolved) return; 
-	m_resolved = true;
-
 	// If we don't exist in the parent symtab, add us as a reference.
 	// If the parent doesn't exist, we're in the global block, so 
 	// nothing could call is anyway.
@@ -493,6 +476,23 @@ void FunctionStmt::resolve() {
 
 	// Add us as a structure.
 	symtab()->setStructure(this);
+	
+	if (isGeneric()) return;
+
+	pushBlock();
+	
+	for (auto param : m_parameters) {
+		param->initialize(); 
+	}
+
+	Block::initialize();
+
+	popBlock();
+}
+
+void FunctionStmt::resolve() {
+	if (m_resolved) return; 
+	m_resolved = true;
 
 	if (isGeneric()) {
 		// We don't actually want to resolve our parameters or body since as a generic function, they will never 

--- a/tools/orange/FunctionStmt.cc
+++ b/tools/orange/FunctionStmt.cc
@@ -220,6 +220,7 @@ FunctionStmt* FunctionStmt::createGenericClone(ArgList args) {
 	}
 
 	clone->initialize();
+	clone->mapDependencies();
 	clone->copyProperties(this);
 	return clone;
 }
@@ -556,6 +557,11 @@ std::string FunctionStmt::dump() {
 	}
 
 	ss << "[" << getClass() << "] " << ID() << " " << this << std::endl;
+
+	if (m_dependency) {
+		ss << "\t@ [" << m_dependency->getClass() << "] " << m_dependency->ID() << " " << m_dependency << std::endl;
+	}
+
 
 	for (auto child : m_children) {
 		std::vector<std::string> lines = split(child->dump(), '\n');

--- a/tools/orange/FunctionStmt.cc
+++ b/tools/orange/FunctionStmt.cc
@@ -334,13 +334,18 @@ Value* FunctionStmt::Codegen() {
 	if (hasReturn() == false && GE::builder()->GetInsertBlock()->getTerminator() == nullptr) {
 		if (isRoot()) {
 			GE::builder()->CreateStore(ConstantInt::getSigned(funcType->getReturnType(), 0), m_retVal);
-		} else if (m_type != nullptr && m_type->isVoidTy() == false) {
+		} else if (m_type != nullptr && m_type->isVoidTy() == false && hasReturnNested() == false) {
 			throw CompilerMessage(*this, "Missing return type; expected a " + m_type->string());
 		}
 
 		// Jump to the end now.
 		GE::builder()->CreateBr(m_blockEnd);
 	} 
+
+	// If we're not using the continue block, just remove it.
+	if (GE::builder()->GetInsertBlock()->size() == 0) {
+		GE::builder()->GetInsertBlock()->eraseFromParent();
+	}
 
 	GE::builder()->SetInsertPoint(m_blockEnd);
 

--- a/tools/orange/FunctionStmt.cc
+++ b/tools/orange/FunctionStmt.cc
@@ -261,19 +261,6 @@ std::vector<ReturnStmt *> allReturnStmts(ASTNode* root) {
 }
 
 Value* FunctionStmt::Codegen() {
-	// Activate ourself in the parent symtab.
-	if (symtab()->container() != nullptr) {
-		bool activated = symtab()->container()->activate(m_orig_name, this);
-		
-		if (activated == false) {
-			throw std::runtime_error("fatal: could not activate " + m_name);
-		}
-	}
-	
-	// Activate ourself.
-	// We don't want to reset the symbol table here; it is not necessary for functions.
-	symtab()->activate(m_orig_name, this);
-
 	// Check to see if we're a generic function. 
 	// If we are, we only should generate our clones since we're incomplete. 
 	if (isGeneric()) {
@@ -469,6 +456,9 @@ BasicBlock* FunctionStmt::createBasicBlock(std::string name) {
 
 
 void FunctionStmt::resolve() {
+	if (m_resolved) return; 
+	m_resolved = true;
+
 	// If we don't exist in the parent symtab, add us as a reference.
 	// If the parent doesn't exist, we're in the global block, so 
 	// nothing could call is anyway.
@@ -511,7 +501,6 @@ void FunctionStmt::resolve() {
 	for (auto param : m_parameters) {
 		param->create();
 	}
-
 
 	Block::resolve();
 

--- a/tools/orange/FunctionStmt.cc
+++ b/tools/orange/FunctionStmt.cc
@@ -187,6 +187,8 @@ FunctionStmt* FunctionStmt::createGenericClone(ArgList args) {
 		clone = new FunctionStmt(cloned_name, cloned_params, symtab()->clone());
 	}
 
+	clone->m_ID = m_ID;
+
 	clone->copyProperties(this);
 	clone->m_mangled = true;
 	

--- a/tools/orange/IfStmts.cc
+++ b/tools/orange/IfStmts.cc
@@ -127,6 +127,9 @@ void IfStmts::resolve() {
 	m_locked = true; 
 
 	ASTNode::resolve();
+
+	if (m_resolved) return; 
+	m_resolved = true;
 }
 
 void IfStmts::addBlock(Block* block) {

--- a/tools/orange/IfStmts.cc
+++ b/tools/orange/IfStmts.cc
@@ -116,6 +116,8 @@ ASTNode* IfStmts::clone() {
 	for (auto block : m_blocks) {
 		clone->addBlock((Block *)block->clone());
 	}
+	
+	clone->copyProperties(this);
 	return clone; 
 }
 

--- a/tools/orange/IncrementExpr.cc
+++ b/tools/orange/IncrementExpr.cc
@@ -59,6 +59,9 @@ ASTNode* IncrementExpr::clone() {
 void IncrementExpr::resolve() {
 	ASTNode::resolve();
 
+	if (m_resolved) return; 
+	m_resolved = true;
+
 	if (m_expr->returnsPtr() == false) {
 		throw CompilerMessage(*m_expr, "expression must be a variable or a memory location!");
 	}

--- a/tools/orange/IncrementExpr.cc
+++ b/tools/orange/IncrementExpr.cc
@@ -51,11 +51,9 @@ Value* IncrementExpr::Codegen() {
 }
 
 ASTNode* IncrementExpr::clone() {
-	return new IncrementExpr((Expression *)m_expr->clone(), m_op, m_preincrement);
-}
-
-OrangeTy* IncrementExpr::getType() {
-	return m_expr->getType();
+	auto clone = new IncrementExpr((Expression *)m_expr->clone(), m_op, m_preincrement);
+	clone->copyProperties(this);
+	return clone;
 }
 
 void IncrementExpr::resolve() {
@@ -64,6 +62,8 @@ void IncrementExpr::resolve() {
 	if (m_expr->returnsPtr() == false) {
 		throw CompilerMessage(*m_expr, "expression must be a variable or a memory location!");
 	}
+
+	m_type = m_expr->getType();
 }
 
 

--- a/tools/orange/Loop.cc
+++ b/tools/orange/Loop.cc
@@ -204,6 +204,7 @@ ASTNode* Loop::clone() {
 		}
 	}
 
+	cloneLoop->copyProperties(this);
 	return cloneLoop;
 }
 

--- a/tools/orange/Loop.cc
+++ b/tools/orange/Loop.cc
@@ -80,9 +80,6 @@ bool Loop::isForeverLoop() const {
 }
 
 Value* Loop::Codegen() {
-	// Reset the symbol table.
-	symtab()->reset();
-
 	// First, we create our blocks.
 	m_condition_block    = getContainingFunction()->createBasicBlock("condition");
 	m_body_block         = getContainingFunction()->createBasicBlock("body");

--- a/tools/orange/Loop.cc
+++ b/tools/orange/Loop.cc
@@ -205,6 +205,12 @@ ASTNode* Loop::clone() {
 	return cloneLoop;
 }
 
+void Loop::initialize() {
+	pushBlock();
+	ASTNode::initialize();
+	popBlock();
+}
+
 void Loop::resolve() {
 	// As with all things that inherit from block, we need to push our symtab first.
 	GE::runner()->pushBlock(this);

--- a/tools/orange/NegativeExpr.cc
+++ b/tools/orange/NegativeExpr.cc
@@ -39,6 +39,10 @@ Value* NegativeExpr::Codegen() {
 
 void NegativeExpr::resolve() {
 	ASTNode::resolve();
+
+	if (m_resolved) return; 
+	m_resolved = true;
+
 	m_type = m_expr->getType();
 }
 

--- a/tools/orange/NegativeExpr.cc
+++ b/tools/orange/NegativeExpr.cc
@@ -37,10 +37,11 @@ Value* NegativeExpr::Codegen() {
 	return m_value;
 }
 
-std::string NegativeExpr::string() {
-	return "-" + m_expr->string();
+void NegativeExpr::resolve() {
+	ASTNode::resolve();
+	m_type = m_expr->getType();
 }
 
-OrangeTy* NegativeExpr::getType() {
-	return m_expr->getType();
+std::string NegativeExpr::string() {
+	return "-" + m_expr->string();
 }

--- a/tools/orange/ReturnStmt.cc
+++ b/tools/orange/ReturnStmt.cc
@@ -71,6 +71,9 @@ Value* ReturnStmt::Codegen() {
 
 void ReturnStmt::resolve() {
 	ASTNode::resolve();
+
+	if (m_resolved) return; 
+	m_resolved = true;
 	
 	if (m_expr) m_type = m_expr->getType();
 	else m_type = VoidTy::get();

--- a/tools/orange/ReturnStmt.cc
+++ b/tools/orange/ReturnStmt.cc
@@ -69,7 +69,10 @@ Value* ReturnStmt::Codegen() {
 	return m_value;
 }
 
-OrangeTy* ReturnStmt::getType() {
-	if (m_expr) return m_expr->getType();
-	return VoidTy::get();
+void ReturnStmt::resolve() {
+	ASTNode::resolve();
+	
+	if (m_expr) m_type = m_expr->getType();
+	else m_type = VoidTy::get();
 }
+

--- a/tools/orange/SizeOfExpr.cc
+++ b/tools/orange/SizeOfExpr.cc
@@ -104,14 +104,12 @@ void SizeOfExpr::resolve() {
 	m_resolved = true;
 
 	if (m_expr) { 
-		m_expr->newID();
 		m_expr->resolve();
 	} else if (m_type && m_type->isVariadicArray()) {
 		auto tp = m_type; 
 
 		while (tp->isArrayTy()) {
 			if (tp->isVariadicArray()) {
-				tp->getVariadicArrayElement()->newID();
 				tp->getVariadicArrayElement()->resolve();
 			}
 
@@ -122,8 +120,18 @@ void SizeOfExpr::resolve() {
 
 SizeOfExpr::SizeOfExpr(OrangeTy* type) {
 	m_type = type;
+
+	auto tp = m_type;
+	while (tp->isArrayTy()) {
+		if (tp->isVariadicArray()) {
+			addChild(tp->getVariadicArrayElement());
+		}
+
+		tp = tp->getArrayElementType();
+	}
 }
 
 SizeOfExpr::SizeOfExpr(Expression* expr) {
 	m_expr = expr; 
+	addChild(expr);
 }

--- a/tools/orange/SizeOfExpr.cc
+++ b/tools/orange/SizeOfExpr.cc
@@ -103,12 +103,15 @@ void SizeOfExpr::resolve() {
 	if (m_resolved) return; 
 	m_resolved = true;
 
-	if (m_expr) m_expr->resolve();
-	else if (m_type && m_type->isVariadicArray()) {
+	if (m_expr) { 
+		m_expr->newID();
+		m_expr->resolve();
+	} else if (m_type && m_type->isVariadicArray()) {
 		auto tp = m_type; 
 
 		while (tp->isArrayTy()) {
 			if (tp->isVariadicArray()) {
+				tp->getVariadicArrayElement()->newID();
 				tp->getVariadicArrayElement()->resolve();
 			}
 

--- a/tools/orange/SizeOfExpr.cc
+++ b/tools/orange/SizeOfExpr.cc
@@ -100,6 +100,9 @@ ASTNode* SizeOfExpr::clone() {
 }
 
 void SizeOfExpr::resolve() {
+	if (m_resolved) return; 
+	m_resolved = true;
+
 	if (m_expr) m_expr->resolve();
 	else if (m_type && m_type->isVariadicArray()) {
 		auto tp = m_type; 

--- a/tools/orange/SizeOfExpr.cc
+++ b/tools/orange/SizeOfExpr.cc
@@ -87,11 +87,16 @@ Value* SizeOfExpr::Codegen() {
 }
 
 ASTNode* SizeOfExpr::clone() {
+	ASTNode* clone = nullptr;
+
 	if (m_expr) {
-		return new SizeOfExpr(m_expr); 
+		clone = new SizeOfExpr(m_expr); 
 	} else {
-		return new SizeOfExpr(m_type);
+		clone = new SizeOfExpr(m_type);
 	}
+
+	clone->copyProperties(this);
+	return clone;
 }
 
 void SizeOfExpr::resolve() {

--- a/tools/orange/SymTable.cc
+++ b/tools/orange/SymTable.cc
@@ -32,6 +32,16 @@ bool SymTable::create(std::string name, ASTNode* node) {
 	return true; 
 }
 
+ASTNode* SymTable::get(std::string name) {
+	auto it = m_objs.find(name); 
+
+	if (it != m_objs.end()) {
+		return it->second->node; 
+	} else {
+		return nullptr;
+	}
+}
+
 ASTNode* SymTable::find(std::string name, bool includeInactive) {
 	auto it = m_objs.find(name); 
 

--- a/tools/orange/SymTable.cc
+++ b/tools/orange/SymTable.cc
@@ -43,31 +43,21 @@ ASTNode* SymTable::get(std::string name) {
 }
 
 bool SymTable::nodeValidFrom(ASTNode* node, ASTNode* from) {
-	auto siblings = from->siblings();
-	unsigned int fromPos = 0;
-
-	for (unsigned int i = 0; i < siblings.size(); i++) {
-		if (siblings[i] == from) {
-			fromPos = i;
-			break;
-		}
-	}
-
-	// Look at the siblings after fromPos. If any of them 
-	// contain node, then we're invalid.
-	for (auto i = fromPos; i < siblings.size(); i++) {
-		auto sibling = siblings[i];
-		if (sibling->contains(node)) {
-			return false;
-		}
-	}
-
-	return true;
+	return node->ID() < from->ID();
 }
 
 
 ASTNode* SymTable::find(std::string name, ASTNode* from) {
+	std::cout << "Things in SymTable:\n";
+	for (auto kvp : m_objs) {
+		std::cout << "\t" << kvp.first << std::endl;
+	}
+
+	std::cout << "Find " << name << std::endl;
+
 	auto it = m_objs.find(name); 
+
+	std::cout << (it == m_objs.end()) << std::endl;
 
 	// return null if it doesn't exist 
 	if (it == m_objs.end() || nodeValidFrom(it->second, from) == false) {

--- a/tools/orange/SymTable.cc
+++ b/tools/orange/SymTable.cc
@@ -48,16 +48,7 @@ bool SymTable::nodeValidFrom(ASTNode* node, ASTNode* from) {
 
 
 ASTNode* SymTable::find(std::string name, ASTNode* from) {
-	std::cout << "Things in SymTable:\n";
-	for (auto kvp : m_objs) {
-		std::cout << "\t" << kvp.first << std::endl;
-	}
-
-	std::cout << "Find " << name << std::endl;
-
 	auto it = m_objs.find(name); 
-
-	std::cout << (it == m_objs.end()) << std::endl;
 
 	// return null if it doesn't exist 
 	if (it == m_objs.end() || nodeValidFrom(it->second, from) == false) {

--- a/tools/orange/TernaryExpr.cc
+++ b/tools/orange/TernaryExpr.cc
@@ -91,6 +91,9 @@ ASTNode* TernaryExpr::clone() {
 void TernaryExpr::resolve() { 
 	ASTNode::resolve();
 
+	if (m_resolved) return; 
+	m_resolved = true;
+
 	// If the true and false expr types aren't compatible with one another, throw an error
 	if (CastingEngine::AreTypesCompatible(m_true_expr->getType(), m_false_expr->getType()) == false) {
 		std::string errorStr = "Types "; 

--- a/tools/orange/TernaryExpr.cc
+++ b/tools/orange/TernaryExpr.cc
@@ -81,12 +81,11 @@ Value* TernaryExpr::Codegen() {
 }
 
 ASTNode* TernaryExpr::clone() { 
-	return new TernaryExpr((Expression *)m_condition->clone(), (Expression *)m_true_expr->clone(), 
+	auto clone = new TernaryExpr((Expression *)m_condition->clone(), (Expression *)m_true_expr->clone(), 
 		(Expression *)m_false_expr->clone());
-}
 
-OrangeTy* TernaryExpr::getType() {
-	return CastingEngine::GetFittingType(m_true_expr->getType(), m_false_expr->getType());
+	clone->copyProperties(this);
+	return clone;
 }
 
 void TernaryExpr::resolve() { 
@@ -98,7 +97,9 @@ void TernaryExpr::resolve() {
 		errorStr += m_true_expr->getType()->string() + " and " + m_false_expr->getType()->string();
 		errorStr += " can not be casted to fit!";
 		throw CompilerMessage(*this, errorStr);
-	}
+	}	
+
+	m_type = CastingEngine::GetFittingType(m_true_expr->getType(), m_false_expr->getType());
 }
 
 bool TernaryExpr::isSigned() {

--- a/tools/orange/VarExpr.cc
+++ b/tools/orange/VarExpr.cc
@@ -55,7 +55,7 @@ std::string VarExpr::string() {
 OrangeTy* VarExpr::getType() {
 	// If we've been assigned a value, we'll return that, otherwise 
 	// we'll return the default type from ASTNode.	
-	if (m_type) {
+	if (m_type && m_type->isVoidTy() == false) {
 		return m_type; 
 	} 
 

--- a/tools/orange/VarExpr.cc
+++ b/tools/orange/VarExpr.cc
@@ -75,7 +75,7 @@ void VarExpr::create() {
 		// We couldn't create it because it already exists. 
 		// If the ASTNode in the table isn't this var, throw an error.
 		if (tab->find(m_name, this) && tab->find(m_name, this) != this) {
-//			throw CompilerMessage(*this, "A variable by this name already exists!");
+			throw CompilerMessage(*this, "A variable by this name already exists!");
 		} 
 	}
 }

--- a/tools/orange/VarExpr.cc
+++ b/tools/orange/VarExpr.cc
@@ -37,28 +37,6 @@ std::string VarExpr::string() {
 	return "(" + getType()->string() + ")" + m_name; 
 }
 
-OrangeTy* VarExpr::getType() {
-	// If we've been assigned a value, we'll return that, otherwise 
-	// we'll return the default type from ASTNode.	
-	if (m_type && m_type->isVoidTy() == false) {
-		return m_type; 
-	} 
-
-	if (ASTNode* node = GE::runner()->topBlock()->symtab()->find(m_name, this)) {
-		if (node->getClass() != getClass()) {
-			throw std::runtime_error(node->string() + " is not a variable!");
-		}
-
-		VarExpr* nodeExpr = (VarExpr*)node;
-
-		if (nodeExpr != this) {
-			return nodeExpr->m_type ? nodeExpr->m_type : nodeExpr->getType();
-		}
-	} 
-
-	return ASTNode::getType();
-}
-
 void VarExpr::setType(OrangeTy* type) {
 	m_type = type;
 }

--- a/tools/orange/VarExpr.cc
+++ b/tools/orange/VarExpr.cc
@@ -47,7 +47,7 @@ void VarExpr::resolve() {
 	}
 }
 
-void VarExpr::create() {
+void VarExpr::initialize() {
 	// Tries to add this variable to the symbol table.
 	// If it already exists in the symbol table, and it's not this, throw an error.
 	SymTable* tab = GE::runner()->topBlock()->symtab();

--- a/tools/orange/VarExpr.cc
+++ b/tools/orange/VarExpr.cc
@@ -42,6 +42,7 @@ void VarExpr::resolve() {
 		}
 
 		for (auto expr : variadicElements) {
+			if (expr) expr->newID();
 			if (expr) expr->resolve();
 		}
 	}

--- a/tools/orange/VarExpr.cc
+++ b/tools/orange/VarExpr.cc
@@ -9,27 +9,8 @@
 #include <orange/VarExpr.h>
 #include <orange/generator.h>
 
-VarExpr* VarExpr::symtabVar() {
-	SymTable* tab = GE::runner()->topBlock()->symtab();
-	ASTNode* tabVar = tab->find(m_name, this);
-	return tabVar ? (VarExpr*)tabVar : this; 
-}
-
 
 Value* VarExpr::Codegen() {
-	// "Generating" a variable doesn't actually do anything; 
-	// its creation is handled by other classes like BinOpExpr.
-	m_value = getValue();
-
-	if (m_value == nullptr) {
-		throw CompilerMessage(*this, "No value determined for " + m_name);
-	}
-
-	return m_value; 
-}
-
-Value* VarExpr::getValue() {
-
 	return m_value;
 }
 

--- a/tools/orange/VarExpr.cc
+++ b/tools/orange/VarExpr.cc
@@ -11,7 +11,7 @@
 
 VarExpr* VarExpr::symtabVar() {
 	SymTable* tab = GE::runner()->topBlock()->symtab();
-	ASTNode* tabVar = tab->find(m_name);
+	ASTNode* tabVar = tab->find(m_name, this);
 	return tabVar ? (VarExpr*)tabVar : this; 
 }
 
@@ -19,32 +19,17 @@ VarExpr* VarExpr::symtabVar() {
 Value* VarExpr::Codegen() {
 	// "Generating" a variable doesn't actually do anything; 
 	// its creation is handled by other classes like BinOpExpr.
-	GE::runner()->topBlock()->symtab()->activate(m_name, this);
 	m_value = getValue();
 
 	if (m_value == nullptr) {
-		throw CompilerMessage(*this, m_name + " doesn't exist!");
+		throw CompilerMessage(*this, "No value determined for " + m_name);
 	}
 
 	return m_value; 
 }
 
 Value* VarExpr::getValue() {
-	// IF we have a value, just return it.
-	if (m_value) return m_value;
 
-	// If a variable exists in the symtab by this name, 
-	SymTable* tab = GE::runner()->topBlock()->symtab();
-
-	ASTNode* node = tab->find(m_name);
-	if (node == nullptr) return m_value; 
-
-	if (node->getClass() != getClass()) {
-		throw std::runtime_error(node->string() + " is not a variable!");
-	}
-
-	if (node == this) return nullptr;
-	m_value = node->getValue();
 	return m_value;
 }
 
@@ -59,9 +44,7 @@ OrangeTy* VarExpr::getType() {
 		return m_type; 
 	} 
 
-	if (GE::runner()->topBlock()->symtab()->find(m_name)) {
-		ASTNode* node = GE::runner()->topBlock()->symtab()->find(m_name);
-
+	if (ASTNode* node = GE::runner()->topBlock()->symtab()->find(m_name, this)) {
 		if (node->getClass() != getClass()) {
 			throw std::runtime_error(node->string() + " is not a variable!");
 		}
@@ -78,31 +61,18 @@ OrangeTy* VarExpr::getType() {
 
 void VarExpr::setType(OrangeTy* type) {
 	m_type = type;
-	
-	// If this variable exists in the symtab, set this type for that, too.
-	SymTable* tab = GE::runner()->topBlock()->symtab();
-	ASTNode* tabVar = tab->find(m_name);
-	
-	if (tabVar && tabVar->getClass() == "VarExpr" && tabVar != this) {
-			((VarExpr *)tabVar)->setType(type);
-	}
 }
 
 bool VarExpr::isLocked() {
 	if (m_locked) return true; 
 
-	// we may not be referring to the VarExpr here; look in the symtab.
-	SymTable* tab = GE::runner()->topBlock()->symtab();
-	ASTNode* tabVar = tab->find(m_name);
-
-	if (tabVar && tabVar->getClass() == "VarExpr" && tabVar != this) {
-		return ((VarExpr *)tabVar)->isLocked();
-	}
-
 	return false;
 }
 
 void VarExpr::resolve() {
+	if (m_resolved) return; 
+	m_resolved = true;
+
 	if (getType()->isVariadicArray()) {
 		std::vector<Expression *> variadicElements; 
 
@@ -118,23 +88,23 @@ void VarExpr::resolve() {
 	}
 }
 
-void VarExpr::create(bool throwError) {
+void VarExpr::create() {
 	// Tries to add this variable to the symbol table.
 	// If it already exists in the symbol table, and it's not this, throw an error.
 	SymTable* tab = GE::runner()->topBlock()->symtab();
 
-	if (tab->create(m_name, this) == false && throwError) {
+	if (tab->create(m_name, this) == false) {
 		// We couldn't create it because it already exists. 
 		// If the ASTNode in the table isn't this var, throw an error.
-		if (tab->find(m_name) && tab->find(m_name) != this) {
-			throw std::runtime_error("A variable by this name already exists!");
+		if (tab->find(m_name, this) && tab->find(m_name, this) != this) {
+//			throw CompilerMessage(*this, "A variable by this name already exists!");
 		} 
 	}
 }
 
 bool VarExpr::existsInParent() {
 	SymTable* tab = GE::runner()->topBlock()->symtab();
-	return tab->find(m_name) != nullptr;
+	return tab->find(m_name, this) != nullptr;
 }
 
 void VarExpr::createValue(Value* value) {

--- a/tools/orange/VarExpr.cc
+++ b/tools/orange/VarExpr.cc
@@ -20,6 +20,20 @@ std::string VarExpr::string() {
 
 void VarExpr::setType(OrangeTy* type) {
 	m_type = type;
+
+	if (getType()->isVariadicArray()) {
+		std::vector<Expression *> variadicElements; 
+
+		auto ptr = getType(); 
+		while (ptr->isVariadicArray()) {
+			variadicElements.push_back(ptr->getVariadicArrayElement());
+			ptr = ptr->getArrayElementType();
+		}
+
+		for (auto expr : variadicElements) {
+			addChild(expr);
+		}
+	}
 }
 
 bool VarExpr::isLocked() {
@@ -42,7 +56,6 @@ void VarExpr::resolve() {
 		}
 
 		for (auto expr : variadicElements) {
-			if (expr) expr->newID();
 			if (expr) expr->resolve();
 		}
 	}
@@ -157,11 +170,11 @@ VarExpr::VarExpr(std::string name, bool constant) : m_name(name) {
 
 VarExpr::VarExpr(std::string name, OrangeTy* type) : m_name(name) {
 	m_locked = true;
-	m_type = type; 
+	setType(type);
 }
 
 VarExpr::VarExpr(std::string name, OrangeTy* type, bool constant) : m_name(name) {
 	m_locked = true;
 	m_constant = constant;
-	m_type = type; 
+	setType(type);
 }

--- a/tools/orange/parser.cc
+++ b/tools/orange/parser.cc
@@ -558,23 +558,23 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   101,   101,   106,   107,   111,   112,   116,   117,   125,
-     126,   127,   128,   129,   130,   131,   132,   133,   134,   135,
-     136,   137,   141,   142,   146,   147,   148,   149,   150,   152,
-     153,   154,   155,   156,   157,   159,   160,   162,   163,   164,
-     166,   167,   169,   170,   171,   173,   175,   177,   178,   179,
-     183,   187,   188,   189,   190,   191,   192,   193,   194,   196,
-     197,   199,   200,   202,   203,   205,   210,   211,   215,   215,
-     220,   220,   227,   228,   232,   233,   234,   238,   245,   246,
-     250,   251,   255,   259,   255,   272,   276,   272,   280,   280,
-     289,   295,   309,   309,   320,   330,   330,   338,   338,   346,
-     346,   354,   354,   366,   371,   376,   383,   384,   385,   389,
-     403,   404,   405,   406,   410,   411,   415,   416,   419,   420,
-     424,   425,   429,   430,   431,   432,   435,   436,   440,   441,
-     442,   446,   447,   451,   452,   456,   457,   458,   459,   460,
-     461,   462,   463,   464,   465,   466,   467,   468,   469,   470,
-     474,   494,   505,   506,   507,   511,   512,   515,   516,   519,
-     520,   521
+       0,    99,    99,   104,   105,   109,   110,   114,   115,   123,
+     124,   125,   126,   127,   128,   129,   130,   131,   132,   133,
+     134,   135,   139,   140,   144,   145,   146,   147,   148,   150,
+     151,   152,   153,   154,   155,   157,   158,   160,   161,   162,
+     164,   165,   167,   168,   169,   171,   173,   175,   176,   177,
+     181,   185,   186,   187,   188,   189,   190,   191,   192,   194,
+     195,   197,   198,   200,   201,   203,   208,   209,   213,   213,
+     218,   218,   225,   226,   230,   231,   232,   236,   243,   244,
+     248,   249,   253,   257,   253,   270,   274,   270,   278,   278,
+     287,   293,   309,   309,   320,   331,   331,   339,   339,   347,
+     347,   355,   355,   367,   373,   379,   387,   388,   389,   393,
+     407,   408,   409,   410,   414,   415,   419,   420,   423,   424,
+     428,   429,   433,   434,   435,   436,   439,   440,   444,   445,
+     446,   450,   451,   455,   456,   460,   461,   462,   463,   464,
+     465,   466,   467,   468,   469,   470,   471,   472,   473,   474,
+     478,   498,   509,   510,   511,   515,   516,   519,   520,   523,
+     524,   525
 };
 #endif
 
@@ -1943,37 +1943,37 @@ yyreduce:
   switch (yyn)
     {
         case 3:
-#line 106 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 104 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyvsp[-1].block)->addStatement((yyvsp[0].node)); }
 #line 1949 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 4:
-#line 107 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 105 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.block) = GE::runner()->topBlock(); (yyval.block)->addStatement((yyvsp[0].node)); }
 #line 1955 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 5:
-#line 111 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 109 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.block) = (yyvsp[0].block); }
 #line 1961 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 6:
-#line 112 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 110 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.block) = GE::runner()->topBlock(); }
 #line 1967 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 7:
-#line 116 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 114 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.node) = nullptr; }
 #line 1973 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 8:
-#line 117 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 115 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		if ((yyvsp[-1].arglist)->size() > 0) {
 			(yyvsp[-1].arglist)->push_back((yyvsp[-2].expr));
@@ -1986,361 +1986,361 @@ yyreduce:
     break;
 
   case 9:
-#line 125 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 123 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.node) = (yyvsp[-1].stmt); }
 #line 1992 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 10:
-#line 126 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 124 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.node) = (yyvsp[-1].stmt); }
 #line 1998 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 11:
-#line 127 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 125 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.node) = (yyvsp[-1].stmt); }
 #line 2004 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 12:
-#line 128 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 126 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.node) = (yyvsp[-1].stmt); }
 #line 2010 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 13:
-#line 129 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 127 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.node) = (yyvsp[-1].stmt); }
 #line 2016 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 14:
-#line 130 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 128 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.node) = (yyvsp[-1].stmt); }
 #line 2022 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 15:
-#line 131 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 129 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.node) = (yyvsp[-1].stmt); }
 #line 2028 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 16:
-#line 132 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 130 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.node) = (yyvsp[-1].stmt); }
 #line 2034 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 17:
-#line 133 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 131 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.node) = (yyvsp[-1].node); }
 #line 2040 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 18:
-#line 134 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 132 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.node) = (yyvsp[-1].stmt); }
 #line 2046 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 19:
-#line 135 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 133 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.node) = (yyvsp[-1].stmt); }
 #line 2052 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 20:
-#line 136 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 134 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.node) = (yyvsp[-1].stmt); }
 #line 2058 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 21:
-#line 137 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 135 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.node) = (yyvsp[-1].stmt); }
 #line 2064 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 22:
-#line 141 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 139 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyvsp[0].arglist)->push_back((yyvsp[-1].expr)); (yyval.arglist) = (yyvsp[0].arglist); }
 #line 2070 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 23:
-#line 142 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 140 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.arglist) = new ArgList(); }
 #line 2076 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 24:
-#line 146 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 144 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2082 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 25:
-#line 147 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 145 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2088 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 26:
-#line 148 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 146 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2094 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 27:
-#line 149 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 147 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2100 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 28:
-#line 150 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 148 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2106 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 29:
-#line 152 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 150 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2112 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 30:
-#line 153 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 151 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2118 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 31:
-#line 154 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 152 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2124 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 32:
-#line 155 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 153 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2130 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 33:
-#line 156 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 154 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2136 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 34:
-#line 157 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 155 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2142 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 35:
-#line 159 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 157 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2148 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 36:
-#line 160 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 158 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2154 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 37:
-#line 162 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 160 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2160 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 38:
-#line 163 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 161 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2166 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 39:
-#line 164 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 162 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2172 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 40:
-#line 166 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 164 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2178 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 41:
-#line 167 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 165 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2184 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 42:
-#line 169 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 167 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2190 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 43:
-#line 170 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 168 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2196 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 44:
-#line 171 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 169 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new BinOpExpr((yyvsp[-2].expr), *(yyvsp[-1].strele), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2202 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 45:
-#line 173 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 171 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new TernaryExpr((yyvsp[-4].expr), (yyvsp[-2].expr), (yyvsp[0].expr)); SET_LOCATION((yyval.expr)); }
 #line 2208 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 46:
-#line 175 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 173 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new DotExpr(new AnyID(*(yyvsp[-2].str)), *(yyvsp[0].str)); }
 #line 2214 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 47:
-#line 177 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 175 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = (yyvsp[0].expr); }
 #line 2220 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 48:
-#line 178 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 176 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new CastExpr((yyvsp[-2].orangety), (yyvsp[0].expr)); }
 #line 2226 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 49:
-#line 179 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 177 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new AddressOfExpr((yyvsp[0].expr)); }
 #line 2232 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 50:
-#line 183 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 181 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = (yyvsp[0].expr); }
 #line 2238 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 51:
-#line 187 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 185 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = (yyvsp[-1].expr); SET_LOCATION((yyval.expr)); }
 #line 2244 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 52:
-#line 188 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 186 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = (yyvsp[0].expr); SET_LOCATION((yyval.expr)); }
 #line 2250 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 53:
-#line 189 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 187 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new StrVal(*(yyvsp[0].str)); }
 #line 2256 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 54:
-#line 190 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 188 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new AnyID(*(yyvsp[0].str)); SET_LOCATION((yyval.expr)); }
 #line 2262 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 55:
-#line 191 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 189 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new FuncCall(*(yyvsp[-3].str), *(yyvsp[-1].arglist)); SET_LOCATION((yyval.expr)); }
 #line 2268 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 56:
-#line 192 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 190 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new SizeOfExpr((yyvsp[-1].expr)); }
 #line 2274 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 57:
-#line 193 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 191 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new SizeOfExpr((yyvsp[-1].orangety)); }
 #line 2280 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 58:
-#line 194 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 192 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new NegativeExpr((yyvsp[0].expr)); }
 #line 2286 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 59:
-#line 196 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 194 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new IncrementExpr((yyvsp[-1].expr), *(yyvsp[0].strele), false); }
 #line 2292 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 60:
-#line 197 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 195 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new IncrementExpr((yyvsp[0].expr), *(yyvsp[-1].strele), true); }
 #line 2298 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 61:
-#line 199 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 197 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new IncrementExpr((yyvsp[-1].expr), *(yyvsp[0].strele), false); }
 #line 2304 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 62:
-#line 200 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 198 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new IncrementExpr((yyvsp[0].expr), *(yyvsp[-1].strele), true); }
 #line 2310 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 63:
-#line 202 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 200 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new ArrayExpr(*(yyvsp[-1].arglist)); }
 #line 2316 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 64:
-#line 203 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 201 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new ArrayAccess((yyvsp[-3].expr), (yyvsp[-1].expr)); }
 #line 2322 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 65:
-#line 205 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 203 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new DerefExpr((yyvsp[0].expr)); }
 #line 2328 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 66:
-#line 210 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 208 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new AnyID(*(yyvsp[0].str)); }
 #line 2334 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 67:
-#line 211 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 209 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.expr) = new ArrayAccess((yyvsp[-3].expr), (yyvsp[-1].expr)); }
 #line 2340 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 68:
-#line 215 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 213 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { 
 			SymTable *tab = new SymTable(nullptr, GE::runner()->symtab());
 			(yyval.stmt) = new FunctionStmt(*(yyvsp[-4].str), *(yyvsp[-2].paramlist), tab);
@@ -2350,13 +2350,13 @@ yyreduce:
     break;
 
   case 69:
-#line 219 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 217 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.stmt) = (yyvsp[-2].stmt); GE::runner()->popBlock(); SET_LOCATION((yyval.stmt)); }
 #line 2356 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 70:
-#line 220 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 218 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 			SymTable *tab = new SymTable(nullptr, GE::runner()->symtab());
 			(yyval.stmt) = new FunctionStmt(*(yyvsp[-6].str), (yyvsp[-1].orangety), *(yyvsp[-4].paramlist), tab);
@@ -2366,43 +2366,43 @@ yyreduce:
     break;
 
   case 71:
-#line 224 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 222 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.stmt) = (yyvsp[-2].stmt); GE::runner()->popBlock(); SET_LOCATION((yyval.stmt)); }
 #line 2372 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 72:
-#line 227 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 225 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.paramlist) = (yyvsp[0].paramlist); }
 #line 2378 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 73:
-#line 228 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 226 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.paramlist) = new ParamList(); }
 #line 2384 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 74:
-#line 232 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 230 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyvsp[-3].paramlist)->push_back(new VarExpr(*(yyvsp[0].str), (yyvsp[-1].orangety))); }
 #line 2390 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 75:
-#line 233 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 231 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyvsp[-2].paramlist)->setVarArg(true); }
 #line 2396 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 76:
-#line 234 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 232 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.paramlist) = new ParamList(); (yyval.paramlist)->push_back(new VarExpr(*(yyvsp[0].str), (yyvsp[-1].orangety))); }
 #line 2402 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 77:
-#line 239 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 237 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 	 		(yyval.stmt) = new ExternFunction((yyvsp[0].orangety), *(yyvsp[-5].str), *(yyvsp[-3].paramlist));
 	 	}
@@ -2410,31 +2410,31 @@ yyreduce:
     break;
 
   case 78:
-#line 245 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 243 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.arglist) = (yyvsp[0].arglist); }
 #line 2416 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 79:
-#line 246 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 244 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.arglist) = new ArgList(); }
 #line 2422 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 80:
-#line 250 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 248 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyvsp[-2].arglist)->push_back((yyvsp[0].expr)); }
 #line 2428 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 81:
-#line 251 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 249 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.arglist) = new ArgList(); (yyval.arglist)->push_back((yyvsp[0].expr)); }
 #line 2434 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 82:
-#line 255 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 253 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		SymTable *tab = new SymTable(GE::runner()->symtab());
 		(yyval.stmt) = new CondBlock((yyvsp[-1].expr), tab);
@@ -2444,13 +2444,13 @@ yyreduce:
     break;
 
   case 83:
-#line 259 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 257 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { GE::runner()->popBlock(); }
 #line 2450 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 84:
-#line 259 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 257 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { 		
 		(yyval.stmt) = new IfStmts;
 
@@ -2465,7 +2465,7 @@ yyreduce:
     break;
 
   case 85:
-#line 272 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 270 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		SymTable *tab = new SymTable(GE::runner()->symtab());
 		(yyval.stmt) = new CondBlock((yyvsp[-1].expr), tab);
@@ -2475,13 +2475,13 @@ yyreduce:
     break;
 
   case 86:
-#line 276 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 274 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { GE::runner()->popBlock(); }
 #line 2481 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 87:
-#line 276 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 274 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { 		
 		(yyvsp[0].blocklist)->insert((yyvsp[0].blocklist)->begin(), (CondBlock*)(yyvsp[-3].stmt));
 		(yyval.blocklist) = (yyvsp[0].blocklist);
@@ -2490,7 +2490,7 @@ yyreduce:
     break;
 
   case 88:
-#line 280 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 278 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		SymTable *tab = new SymTable(GE::runner()->symtab());
 		(yyval.stmt) = new Block(tab);
@@ -2500,7 +2500,7 @@ yyreduce:
     break;
 
   case 89:
-#line 284 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 282 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		(yyval.blocklist) = new std::vector<Block*>;
 		(yyval.blocklist)->insert((yyval.blocklist)->begin(), (Block*)(yyvsp[-2].stmt));
@@ -2510,7 +2510,7 @@ yyreduce:
     break;
 
   case 90:
-#line 289 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 287 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		(yyval.blocklist) = new std::vector<Block*>;
 	}
@@ -2518,19 +2518,21 @@ yyreduce:
     break;
 
   case 91:
-#line 295 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 293 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		SymTable* tab = new SymTable(GE::runner()->symtab());
 		CondBlock* block = new CondBlock((yyvsp[0].expr), tab);
 		GE::runner()->pushBlock(block);
 
 		block->addStatement((yyvsp[-2].node));
+		(yyvsp[-2].node)->newID();
+
 		(yyval.stmt) = new IfStmts;
 		((IfStmts *)(yyval.stmt))->addBlock(block); 
 
 		GE::runner()->popBlock();
 	}
-#line 2534 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+#line 2536 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 92:
@@ -2540,7 +2542,7 @@ yyreduce:
 		(yyval.stmt) = new CondBlock((yyvsp[-1].expr), tab, true);
 		GE::runner()->pushBlock((CondBlock *)(yyval.stmt));
 	}
-#line 2544 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+#line 2546 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 93:
@@ -2550,7 +2552,7 @@ yyreduce:
 		((IfStmts *)(yyval.stmt))->addBlock((CondBlock*)(yyvsp[-2].stmt)); 
 		SET_LOCATION((yyval.stmt));
 	}
-#line 2554 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+#line 2556 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 94:
@@ -2559,139 +2561,143 @@ yyreduce:
 		SymTable* tab = new SymTable(GE::runner()->symtab());
 		CondBlock* block = new CondBlock((yyvsp[0].expr), tab, true);
 		block->addStatement((yyvsp[-2].node));
+		(yyvsp[-2].node)->newID();
 		(yyval.stmt) = new IfStmts;
 		((IfStmts *)(yyval.stmt))->addBlock(block); 
 	}
-#line 2566 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+#line 2569 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 95:
-#line 330 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 331 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		SymTable *tab = new SymTable(GE::runner()->symtab());
 		(yyval.stmt) = new Loop((yyvsp[-6].node), (yyvsp[-4].expr), (yyvsp[-2].expr), tab);
 		GE::runner()->pushBlock((Loop *)(yyval.stmt));
 	}
-#line 2576 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+#line 2579 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 96:
-#line 334 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 335 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		(yyval.stmt) = (Loop *)(yyvsp[-2].stmt);
 		GE::runner()->popBlock();
 	}
-#line 2585 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+#line 2588 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 97:
-#line 338 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 339 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		SymTable *tab = new SymTable(GE::runner()->symtab());
 		(yyval.stmt) = new Loop((yyvsp[-1].expr), false, tab);
 		GE::runner()->pushBlock((Loop *)(yyval.stmt));		
 	}
-#line 2595 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+#line 2598 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 98:
-#line 342 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 343 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		(yyval.stmt) = (Loop *)(yyvsp[-2].stmt);
 		GE::runner()->popBlock();
 	}
-#line 2604 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+#line 2607 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 99:
-#line 346 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 347 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		SymTable *tab = new SymTable(GE::runner()->symtab());
 		(yyval.stmt) = new Loop(tab);
 		GE::runner()->pushBlock((Loop *)(yyval.stmt));				
 	}
-#line 2614 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+#line 2617 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 100:
-#line 350 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 351 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		(yyval.stmt) = (Loop *)(yyvsp[-2].stmt);
 		GE::runner()->popBlock();
 	}
-#line 2623 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+#line 2626 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 101:
-#line 354 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 355 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		SymTable *tab = new SymTable(GE::runner()->symtab());
 		(yyval.stmt) = new Loop(nullptr, true, tab);
 		GE::runner()->pushBlock((Loop *)(yyval.stmt));				
 	}
-#line 2633 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+#line 2636 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 102:
-#line 358 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 359 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		(yyval.stmt) = (Loop *)(yyvsp[-4].stmt);
 		((Loop *)(yyval.stmt))->setCondition((yyvsp[0].expr));
 		GE::runner()->popBlock();
 	}
-#line 2643 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+#line 2646 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 103:
-#line 366 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 367 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		SymTable *tab = new SymTable(GE::runner()->symtab());
 		(yyval.stmt) = new Loop((yyvsp[-5].node), (yyvsp[-3].expr), (yyvsp[-1].expr), tab);
-		((Loop *)(yyval.stmt))->addStatement((yyvsp[-8].node));		
+		((Loop *)(yyval.stmt))->addStatement((yyvsp[-8].node));
+		(yyvsp[-8].node)->newID();
 	}
-#line 2653 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+#line 2657 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 104:
-#line 371 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 373 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		SymTable *tab = new SymTable(GE::runner()->symtab());
 		(yyval.stmt) = new Loop((yyvsp[0].expr), false, tab);
 		((Loop *)(yyval.stmt))->addStatement((yyvsp[-2].node));				
+		(yyvsp[-2].node)->newID();
 	}
-#line 2663 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+#line 2668 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 105:
-#line 376 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 379 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		SymTable *tab = new SymTable(GE::runner()->symtab());
 		(yyval.stmt) = new Loop(tab);
 		((Loop *)(yyval.stmt))->addStatement((yyvsp[-1].node));
+		(yyvsp[-1].node)->newID();
 	}
-#line 2673 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
-    break;
-
-  case 106:
-#line 383 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.stmt) = new LoopSkip(true); }
 #line 2679 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 107:
-#line 384 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+  case 106:
+#line 387 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.stmt) = new LoopSkip(true); }
 #line 2685 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 108:
-#line 385 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.stmt) = new LoopSkip(false); }
+  case 107:
+#line 388 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.stmt) = new LoopSkip(true); }
 #line 2691 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 109:
+  case 108:
 #line 389 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.stmt) = new LoopSkip(false); }
+#line 2697 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+    break;
+
+  case 109:
+#line 393 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     {
 		EnumStmt* enumStmt = new EnumStmt(*(yyvsp[-3].str));
 		for (auto pair : *(yyvsp[-1].enumlist)) {
@@ -2704,149 +2710,149 @@ yyreduce:
 
 		(yyval.stmt) = (Statement *)enumStmt;
 	}
-#line 2708 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
-    break;
-
-  case 110:
-#line 403 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyvsp[-2].enumlist)->push_back(EnumPair(*(yyvsp[-1].str))); }
 #line 2714 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 111:
-#line 404 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyvsp[-4].enumlist)->push_back(EnumPair(*(yyvsp[-3].str), (BaseVal*)(yyvsp[-1].expr))); }
+  case 110:
+#line 407 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyvsp[-2].enumlist)->push_back(EnumPair(*(yyvsp[-1].str))); }
 #line 2720 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 112:
-#line 405 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.enumlist) = new std::vector<EnumPair>; (yyval.enumlist)->push_back(EnumPair(*(yyvsp[-1].str))); }
+  case 111:
+#line 408 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyvsp[-4].enumlist)->push_back(EnumPair(*(yyvsp[-3].str), (BaseVal*)(yyvsp[-1].expr))); }
 #line 2726 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 113:
-#line 406 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.enumlist) = new std::vector<EnumPair>; (yyval.enumlist)->push_back(EnumPair(*(yyvsp[-3].str), (BaseVal*)(yyvsp[-1].expr))); }
+  case 112:
+#line 409 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.enumlist) = new std::vector<EnumPair>; (yyval.enumlist)->push_back(EnumPair(*(yyvsp[-1].str))); }
 #line 2732 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 114:
+  case 113:
 #line 410 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.node) = (yyvsp[0].stmt); }
+    { (yyval.enumlist) = new std::vector<EnumPair>; (yyval.enumlist)->push_back(EnumPair(*(yyvsp[-3].str), (BaseVal*)(yyvsp[-1].expr))); }
 #line 2738 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 115:
-#line 411 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.node) = (yyvsp[0].expr); }
+  case 114:
+#line 414 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.node) = (yyvsp[0].stmt); }
 #line 2744 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 116:
+  case 115:
 #line 415 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.expr) = (yyvsp[0].expr); }
+    { (yyval.node) = (yyvsp[0].expr); }
 #line 2750 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 117:
-#line 416 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.expr) = nullptr; }
+  case 116:
+#line 419 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.expr) = (yyvsp[0].expr); }
 #line 2756 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 118:
-#line 419 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.stmt) = new ExplicitDeclStmt(new VarExpr(*(yyvsp[-1].str), (yyvsp[-2].orangety)), *(yyvsp[0].declpairlist)); }
+  case 117:
+#line 420 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.expr) = nullptr; }
 #line 2762 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 119:
-#line 420 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.stmt) = new ExplicitDeclStmt(new VarExpr(*(yyvsp[-3].str), (yyvsp[-4].orangety)), (yyvsp[-1].expr), *(yyvsp[0].declpairlist)); }
+  case 118:
+#line 423 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.stmt) = new ExplicitDeclStmt(new VarExpr(*(yyvsp[-1].str), (yyvsp[-2].orangety)), *(yyvsp[0].declpairlist)); }
 #line 2768 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 120:
+  case 119:
 #line 424 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.declpairlist) = (yyvsp[0].declpairlist); }
+    { (yyval.stmt) = new ExplicitDeclStmt(new VarExpr(*(yyvsp[-3].str), (yyvsp[-4].orangety)), (yyvsp[-1].expr), *(yyvsp[0].declpairlist)); }
 #line 2774 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 121:
-#line 425 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.declpairlist) = new std::vector<DeclPair>(); }
+  case 120:
+#line 428 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.declpairlist) = (yyvsp[0].declpairlist); }
 #line 2780 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 122:
+  case 121:
 #line 429 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyvsp[0].declpairlist)->push_back(DeclPair(*(yyvsp[-2].str), nullptr)); }
+    { (yyval.declpairlist) = new std::vector<DeclPair>(); }
 #line 2786 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 123:
-#line 430 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyvsp[0].declpairlist)->push_back(DeclPair(*(yyvsp[-4].str), (yyvsp[-2].expr))); }
+  case 122:
+#line 433 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyvsp[0].declpairlist)->push_back(DeclPair(*(yyvsp[-2].str), nullptr)); }
 #line 2792 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 124:
-#line 431 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.declpairlist) = new std::vector<DeclPair>(); (yyval.declpairlist)->push_back(DeclPair(*(yyvsp[0].str), nullptr)); }
+  case 123:
+#line 434 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyvsp[0].declpairlist)->push_back(DeclPair(*(yyvsp[-4].str), (yyvsp[-2].expr))); }
 #line 2798 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 125:
-#line 432 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.declpairlist) = new std::vector<DeclPair>(); (yyval.declpairlist)->push_back(DeclPair(*(yyvsp[-2].str), (yyvsp[0].expr))); }
+  case 124:
+#line 435 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.declpairlist) = new std::vector<DeclPair>(); (yyval.declpairlist)->push_back(DeclPair(*(yyvsp[0].str), nullptr)); }
 #line 2804 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 126:
-#line 435 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.node) = new ExplicitDeclStmt(new VarExpr(*(yyvsp[-2].str), (yyvsp[-3].orangety), true), (yyvsp[0].expr)); }
+  case 125:
+#line 436 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.declpairlist) = new std::vector<DeclPair>(); (yyval.declpairlist)->push_back(DeclPair(*(yyvsp[-2].str), (yyvsp[0].expr))); }
 #line 2810 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 127:
-#line 436 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.node) = new BinOpExpr(new VarExpr(*(yyvsp[-2].str), true), "=", (yyvsp[0].expr)); }
+  case 126:
+#line 439 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.node) = new ExplicitDeclStmt(new VarExpr(*(yyvsp[-2].str), (yyvsp[-3].orangety), true), (yyvsp[0].expr)); }
 #line 2816 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 128:
+  case 127:
 #line 440 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.node) = (yyvsp[0].stmt); }
+    { (yyval.node) = new BinOpExpr(new VarExpr(*(yyvsp[-2].str), true), "=", (yyvsp[0].expr)); }
 #line 2822 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 129:
-#line 441 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.node) = (yyvsp[0].expr); }
+  case 128:
+#line 444 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.node) = (yyvsp[0].stmt); }
 #line 2828 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 130:
-#line 442 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.node) = (yyvsp[0].stmt); }
+  case 129:
+#line 445 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.node) = (yyvsp[0].expr); }
 #line 2834 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 131:
+  case 130:
 #line 446 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.stmt) = new ReturnStmt(); SET_LOCATION((yyval.stmt)); }
+    { (yyval.node) = (yyvsp[0].stmt); }
 #line 2840 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 132:
-#line 447 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.stmt) = new ReturnStmt((yyvsp[0].expr)); SET_LOCATION((yyval.stmt)); }
+  case 131:
+#line 450 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.stmt) = new ReturnStmt(); SET_LOCATION((yyval.stmt)); }
 #line 2846 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
+  case 132:
+#line 451 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.stmt) = new ReturnStmt((yyvsp[0].expr)); SET_LOCATION((yyval.stmt)); }
+#line 2852 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+    break;
+
   case 150:
-#line 474 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 478 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { 
 		(yyval.orangety) = OrangeTy::get(*(yyvsp[-2].str));
 
@@ -2864,11 +2870,11 @@ yyreduce:
 			}
 		}
 	}
-#line 2868 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+#line 2874 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
   case 151:
-#line 494 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+#line 498 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { 
 		(yyval.orangety) = OrangeTy::get(*(yyvsp[-1].str));
 		
@@ -2877,59 +2883,59 @@ yyreduce:
 			(yyval.orangety) = (yyval.orangety)->getPointerTo();
 		}
 	}
-#line 2881 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
-    break;
-
-  case 152:
-#line 505 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.number)++; }
 #line 2887 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 153:
-#line 506 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+  case 152:
+#line 509 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
     { (yyval.number)++; }
 #line 2893 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 154:
-#line 507 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.number) = 0; }
+  case 153:
+#line 510 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.number)++; }
 #line 2899 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 157:
-#line 515 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyvsp[-3].exprlist)->push_back((yyvsp[-1].expr)); }
+  case 154:
+#line 511 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.number) = 0; }
 #line 2905 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 158:
-#line 516 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.exprlist) = new std::vector<Expression *>(); }
+  case 157:
+#line 519 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyvsp[-3].exprlist)->push_back((yyvsp[-1].expr)); }
 #line 2911 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 159:
-#line 519 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.number)++; }
+  case 158:
+#line 520 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.exprlist) = new std::vector<Expression *>(); }
 #line 2917 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 160:
-#line 520 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.number) = 0; }
+  case 159:
+#line 523 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.number)++; }
 #line 2923 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
-  case 161:
-#line 521 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.number) = 1; }
+  case 160:
+#line 524 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.number) = 0; }
 #line 2929 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 
+  case 161:
+#line 525 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
+    { (yyval.number) = 1; }
+#line 2935 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+    break;
 
-#line 2933 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
+
+#line 2939 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -3164,5 +3170,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 524 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1906  */
+#line 528 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1906  */
 

--- a/tools/orange/parser.cc
+++ b/tools/orange/parser.cc
@@ -2329,7 +2329,7 @@ yyreduce:
 
   case 66:
 #line 210 "/Users/robert/dev/orange/tools/orange/parser.y" /* yacc.c:1661  */
-    { (yyval.expr) = new VarExpr(*(yyvsp[0].str)); }
+    { (yyval.expr) = new AnyID(*(yyvsp[0].str)); }
 #line 2334 "/Users/robert/dev/orange/tools/orange/parser.cc" /* yacc.c:1661  */
     break;
 

--- a/tools/orange/parser.y
+++ b/tools/orange/parser.y
@@ -88,12 +88,10 @@
 %left BITWISE_XOR
 %left BITWISE_AND
 
-
 %left PLUS MINUS
 %left TIMES DIVIDE MOD
 %left OPEN_PAREN CLOSE_PAREN INCREMENT DECREMENT OPEN_BRACKET
 %right SIZEOF
-
 
 %%
 	
@@ -298,6 +296,8 @@ inline_if
 		GE::runner()->pushBlock(block);
 
 		block->addStatement($1);
+		$1->newID();
+
 		$$ = new IfStmts;
 		((IfStmts *)$$)->addBlock(block); 
 
@@ -321,6 +321,7 @@ inline_unless
 		SymTable* tab = new SymTable(GE::runner()->symtab());
 		CondBlock* block = new CondBlock($3, tab, true);
 		block->addStatement($1);
+		$1->newID();
 		$$ = new IfStmts;
 		((IfStmts *)$$)->addBlock(block); 
 	}
@@ -366,17 +367,20 @@ inline_loop
 	: return_or_expr FOR OPEN_PAREN initializer SEMICOLON opt_expr SEMICOLON opt_expr CLOSE_PAREN {
 		SymTable *tab = new SymTable(GE::runner()->symtab());
 		$$ = new Loop($4, $6, $8, tab);
-		((Loop *)$$)->addStatement($1);		
+		((Loop *)$$)->addStatement($1);
+		$1->newID();
 	}
 	| return_or_expr WHILE expression {
 		SymTable *tab = new SymTable(GE::runner()->symtab());
 		$$ = new Loop($3, false, tab);
 		((Loop *)$$)->addStatement($1);				
+		$1->newID();
 	}
 	| return_or_expr FOREVER {
 		SymTable *tab = new SymTable(GE::runner()->symtab());
 		$$ = new Loop(tab);
 		((Loop *)$$)->addStatement($1);
+		$1->newID();
 	}
 
 loop_breaks

--- a/tools/orange/parser.y
+++ b/tools/orange/parser.y
@@ -207,7 +207,7 @@ primary
 	;
 
 opt_array
-	: TYPE_ID { $$ = new VarExpr(*$1); }
+	: TYPE_ID { $$ = new AnyID(*$1); }
 	| opt_array OPEN_BRACKET expression CLOSE_BRACKET { $$ = new ArrayAccess($1, $3); }
 	;
 

--- a/tools/orange/runner.cc
+++ b/tools/orange/runner.cc
@@ -126,8 +126,10 @@ void Runner::compile() {
 			return;
 		}
 
-		if (debug())
+		if (debug()) {
+			std::cout << mainFunction()->dump() << std::endl;
 			std::cout << mainFunction()->string() << std::endl;
+		}
 
 		mainFunction()->Codegen();
 

--- a/tools/orange/runner.cc
+++ b/tools/orange/runner.cc
@@ -118,9 +118,14 @@ void Runner::compile() {
 		yyparse(); // and do our parse.
 
 		// Analysis pass 
+		mainFunction()->initialize();
 		mainFunction()->resolve();
 
 		if (hasError()) {
+			if (debug()) {
+				std::cout << mainFunction()->dump() << std::endl;
+			}
+
 			m_result->finish(false, m_messages);
 			return;
 		}
@@ -137,7 +142,7 @@ void Runner::compile() {
 			return;
 		}
 
-		if (debug())
+		if (debug()) 
 			m_module->dump();
 
 		optimizeModule();

--- a/tools/orange/runner.cc
+++ b/tools/orange/runner.cc
@@ -121,6 +121,7 @@ void Runner::compile() {
 
 		// Analysis pass 
 		mainFunction()->initialize();
+		mainFunction()->mapDependencies();
 		mainFunction()->resolve();
 
 		if (hasError()) {

--- a/tools/orange/runner.cc
+++ b/tools/orange/runner.cc
@@ -121,8 +121,6 @@ void Runner::compile() {
 		mainFunction()->resolve();
 		mainFunction()->fixup();
 
-		std::cout << "Done resolving!\n";
-
 		if (hasError()) {
 			m_result->finish(false, m_messages);
 			return;

--- a/tools/orange/runner.cc
+++ b/tools/orange/runner.cc
@@ -117,9 +117,8 @@ void Runner::compile() {
 		yyin = file; // give flex the file
 		yyparse(); // and do our parse.
 
-		// Now that we've parsed everything, let's analyze and resolve code...
+		// Analysis pass 
 		mainFunction()->resolve();
-		mainFunction()->fixup();
 
 		if (hasError()) {
 			m_result->finish(false, m_messages);

--- a/tools/orange/runner.cc
+++ b/tools/orange/runner.cc
@@ -121,6 +121,8 @@ void Runner::compile() {
 		mainFunction()->resolve();
 		mainFunction()->fixup();
 
+		std::cout << "Done resolving!\n";
+
 		if (hasError()) {
 			m_result->finish(false, m_messages);
 			return;

--- a/tools/orange/runner.cc
+++ b/tools/orange/runner.cc
@@ -116,6 +116,8 @@ void Runner::compile() {
 		yyonce = 0; // reset yyonce
 		yyin = file; // give flex the file
 		yyparse(); // and do our parse.
+		
+		mainFunction()->newID();
 
 		// Analysis pass 
 		mainFunction()->initialize();

--- a/tools/orange/types/VariadicArrayTy.cc
+++ b/tools/orange/types/VariadicArrayTy.cc
@@ -23,6 +23,10 @@ bool VariadicArrayTy::isSigned() const {
 	return m_internal_ty->isSigned();
 }
 
+void VariadicArrayTy::resolve() {
+	m_count->resolve();
+}
+
 VariadicArrayTy* VariadicArrayTy::get(OrangeTy* internalTy, Expression* count) {
 	std::stringstream ss; 
 	ss << internalTy->string() << "[" << (unsigned long long)count << "]";


### PR DESCRIPTION
Types were being determined through every call of `getType()` before. It has been changed so that types are determined once in `m_type`. 

This revealed an issue where some recursive functions could not have their types resolved. I introduced a mechanism to determine statement dependencies. Functions depend on the first return statement that do not depend on a node that does a recursive call. Functions will resolve dependencies first, set its type, and then resolve all other nodes. 