### PR TITLE
Add travis build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+sudo: false
+language: cpp
+compiler:
+  - clang 
+  - gcc
+cache: apt 
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - llvm-toolchain-precise
+    - llvm-toolchain-precise-3.6
+    packages:
+    - llvm-3.6 
+    - llvm-3.6-dev
+    - libedit-dev
+    - g++-4.8
+git:
+  submodules: false
+before_install:
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+script:
+  - mkdir build
+  - cd build 
+  - cmake ..
+  - make all
+  - ./output/bin/orange test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,9 @@ endif()
 
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang") 
 	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11")
-else()
+elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
+	else()
 	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")	
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.8)
+cmake_minimum_required (VERSION 2.8.7)
 project(orange)
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,16 +24,23 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 	ADD_DEFINITIONS(-DDEBUG)
 endif()
 
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang") 
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11")
+else()
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")	
+endif()
+
+
 
 # unix specific flags
 if(${APPLE})
 	MESSAGE(STATUS "Detected OS X...")
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -fexceptions -Wno-unused -Wno-deprecated-register -g")
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fexceptions -Wno-unused -Wno-deprecated-register -g")
 	SET(CMAKE_EXE_LINKER_FLAGS_RELEASE "-Wl,-dead_strip -Wl,-dead_strip_dylibs")
 	LINK_DIRECTORIES(/usr/local/lib)
 	SET(CMAKE_EXE_LINKER_FLAGS "-Wl,-dead_strip -Wl,-dead_strip_dylibs")
 elseif(${UNIX})
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -fexceptions -Wno-unused -g")
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fexceptions -Wno-unused -g")
 	SET(CMAKE_EXE_LINKER_FLAGS "-Wl,--gc-sections")
 endif()
 
@@ -41,7 +48,7 @@ endif()
 if(${WIN32})
 	SET(STATUS "Detected WIN32...")
 
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -fexceptions -Wno-unused ")
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fexceptions -Wno-unused ")
 	SET(CXX_DEFINES "${CXX_DEFINES} -DYY_NO_UNISTD_H")
 	SET(C_DEFINES "${C_DEFINES} -DYY_NO_UNISTD_H")
 endif(${WIN32})

--- a/tools/orange/commands/TestCommand.cc
+++ b/tools/orange/commands/TestCommand.cc
@@ -242,6 +242,11 @@ void TestCommand::run() {
 
 	// Print a newline, since our runOnPath() wouldn't have.
 	std::cout << "\n"; 
+
+	// Exit with 1 if we had at least one failing test.
+	if (numPassedTests() - m_results.size() > 0) {
+		exit(1);
+	}
 }
 
 TestCommand::~TestCommand() { }


### PR DESCRIPTION
Travis will build with clang and gcc. 

`TestCommand` has been changed to exit with a failure code if any of the tests fail, so Travis can detect this.