### PR TITLE
Add test command

### DIFF
--- a/include/cmd/OptionsState.h
+++ b/include/cmd/OptionsState.h
@@ -94,4 +94,6 @@ public:
 	virtual int run(std::vector<std::string> args);
 
 	OptionsState(std::string stateName);
+	
+	virtual ~OptionsState();
 };

--- a/include/orange/TestCommand.h
+++ b/include/orange/TestCommand.h
@@ -1,0 +1,27 @@
+/*
+** Copyright 2014-2015 Robert Fratto. See the LICENSE.txt file at the top-level
+** directory of this distribution.
+**
+** Licensed under the MIT license <http://opensource.org/licenses/MIT>. This file
+** may not be copied, modified, or distributed except according to those terms.
+*/
+
+#pragma once
+
+#include <cmd/OptionsState.h>
+
+/**
+ * TestCommand runs all tests in the test/ directory of an orange project.
+ */
+class TestCommand : public OptionsState
+{
+protected:
+	int output_backup;
+	
+	void disableOutput();
+	void enableOutput();
+public:
+	virtual int run(std::vector<std::string> args) override;
+	
+	TestCommand();
+};

--- a/include/util/file.h
+++ b/include/util/file.h
@@ -30,5 +30,6 @@ std::string combinePaths(std::string a, std::string b);
 std::string getTempFile(std::string prefix, std::string suffix);
 
 /// Recursively get all files in path and return it in a vector
-std::vector<std::string> getFilesRecursive(std::string path);
+std::vector<std::string> getFilesRecursive(std::string path,
+										   std::string ext = "");
 

--- a/lib/cmd/OptionsState.cc
+++ b/lib/cmd/OptionsState.cc
@@ -106,3 +106,8 @@ OptionsState::OptionsState(std::string stateName)
 	
 	m_state_name = stateName;
 }
+
+OptionsState::~OptionsState()
+{
+	// Do nothing.
+}

--- a/lib/util/file.cc
+++ b/lib/util/file.cc
@@ -70,7 +70,7 @@ std::string getTempFile(std::string prefix, std::string suffix)
 	return llvm::Twine(buf).str();
 }
 
-std::vector<std::string> getFilesRecursive(std::string path)
+std::vector<std::string> getFilesRecursive(std::string path, std::string ext)
 {
 	std::vector<std::string> ret;
 	
@@ -102,6 +102,13 @@ std::vector<std::string> getFilesRecursive(std::string path)
 		{
 			continue;
 		}
+		
+		auto fext = llvm::sys::path::extension(entry.path());
+		if (ext != "" && fext != ext)
+		{
+			continue;
+		}
+		
 		ret.push_back(entry.path());
 	}
 	

--- a/lib/util/file.cc
+++ b/lib/util/file.cc
@@ -96,6 +96,12 @@ std::vector<std::string> getFilesRecursive(std::string path)
 			continue;
 		}
 		
+		// If it's a dotfile, continue on
+		auto fname = llvm::sys::path::filename(entry.path());
+		if (fname[0] == '.')
+		{
+			continue;
+		}
 		ret.push_back(entry.path());
 	}
 	

--- a/lib/util/file.cc
+++ b/lib/util/file.cc
@@ -15,7 +15,7 @@
 //using namespace llvm;
 
 
-std::string findProjectDirectory()
+std::string findProjectDirectory(std::string target)
 {
 	llvm::SmallString<50> current_path_s;
 	llvm::sys::fs::current_path(current_path_s);
@@ -34,7 +34,7 @@ std::string findProjectDirectory()
 		auto end = llvm_dir_it();
 		for (auto it = llvm_dir_it(path_twine, ec); it != end; it.increment(ec))
 		{
-			if (llvm::sys::path::filename(it->path()).str() == ORANGE_SETTINGS)
+			if (llvm::sys::path::filename(it->path()).str() == target)
 			{
 				return current_path;
 			}

--- a/lib/util/file.cc
+++ b/lib/util/file.cc
@@ -81,7 +81,8 @@ std::vector<std::string> getFilesRecursive(std::string path, std::string ext)
 	
 	if (ec.value() != 0)
 	{
-		throw std::runtime_error(ec.message());
+		std::string err = "No such file or directory: " + path;
+		throw std::runtime_error(err);
 	}
 	
 	for ( ; it != llvm_rdir_it(); it.increment(ec))

--- a/tools/orange/TestCommand.cc
+++ b/tools/orange/TestCommand.cc
@@ -1,0 +1,155 @@
+/*
+** Copyright 2014-2015 Robert Fratto. See the LICENSE.txt file at the top-level
+** directory of this distribution.
+**
+** Licensed under the MIT license <http://opensource.org/licenses/MIT>. This file
+** may not be copied, modified, or distributed except according to those terms.
+*/
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <orange/TestCommand.h>
+#include <grove/Builder.h>
+
+#include <util/file.h>
+
+#ifdef _WIN32
+const char* NULLFILE = "NUL";
+#else
+const char* NULLFILE = "/dev/null";
+#endif
+
+void TestCommand::disableOutput()
+{
+	fflush(stdout);
+	output_backup = dup(STDOUT_FILENO);
+	
+	auto new_fd = open(NULLFILE, O_WRONLY);
+	dup2(new_fd, STDOUT_FILENO);
+	close(new_fd);
+}
+
+void TestCommand::enableOutput()
+{
+	fflush(stdout);
+	dup2(output_backup, STDOUT_FILENO);
+	close(output_backup);
+}
+
+int TestCommand::run(std::vector<std::string> args)
+{
+	auto proj_dir = findProjectDirectory("orange.settings.json");
+	auto test_path = combinePaths(proj_dir, "test/");
+	auto test_files = getFilesRecursive(test_path, ".or");
+	
+	// Number of results (. or F) printed to the screen.
+	int nres_printed = 0;
+	
+	uint32_t tot_time = 0;
+	uint32_t npassed = 0;
+	uint32_t nfailed = 0;
+	
+	std::tuple<std::string, uint32_t> longest_test =
+		std::make_tuple<std::string, uint32_t>("", 0);
+	
+	std::vector<std::tuple<std::string, std::string>> errors;
+	
+	for (auto test : test_files)
+	{
+		// Have path be relative from project directory
+		auto short_path = test.substr(proj_dir.length() + 1);
+		
+		Builder* builder = nullptr;
+		int statusCode = 0;
+		
+		disableOutput();
+		
+		auto start_time = llvm::sys::TimeValue::now();
+		
+		try
+		{
+			builder = new Builder(test);
+			builder->compile();
+			
+			statusCode = builder->run();
+			
+			if (statusCode != 0)
+			{
+    			errors.push_back(std::make_tuple(short_path, "returned "
+				 "nonzero"));
+			}
+		}
+		catch (std::exception& e)
+		{
+			statusCode = 1;
+			
+			errors.push_back(std::make_tuple(short_path, e.what()));
+		}
+		
+		auto finish_time = llvm::sys::TimeValue::now();
+		auto diff = finish_time - start_time;
+		
+		tot_time += diff.milliseconds();
+		
+		if (std::get<0>(longest_test) == "" ||
+			diff.milliseconds() > std::get<1>(longest_test))
+		{
+			longest_test = std::make_tuple(short_path, diff.milliseconds());
+		}
+		
+		enableOutput();
+		
+		if (statusCode == 0)
+		{
+			std::cout << ".";
+			npassed++;
+		}
+		else
+		{
+			std::cout << "F";
+			nfailed++;
+		}
+		
+		if ((++nres_printed % 40) == 0)
+		{
+			std::cout << "\n";
+		}
+			
+		
+		std::flush(std::cout);
+	}
+	
+	std::cout << "\n\n";
+	
+	int percPassed = ((float)npassed/(float)(npassed+nfailed)) * 100;
+	float avgSecs = tot_time/(float)(npassed+nfailed)/1000.0f;
+	
+	std::cout << "Test results (" << tot_time/1000.0f << " seconds)\n";
+	std::cout << "\t" << npassed << "/" << (npassed+nfailed)
+	          << " tests passed (" << percPassed << "%).\n";
+	std::cout << "\t" << avgSecs << " seconds to run on average.\n";
+	std::cout << "\tLongest test was: " << std::get<0>(longest_test)
+	          << " (" << std::get<1>(longest_test)/1000.0f << " seconds)\n\n";
+	
+	if (errors.size() > 0)
+	{
+		std::cout << "Errors:\n";
+		
+		for (auto error : errors)
+		{
+			std::cout << "\t" << std::get<0>(error) << ":\n\t\t"
+			          << std::get<1>(error) << std::endl;
+		}
+		
+    	std::cout << "\n";
+	}
+	
+	
+	return 0;
+}
+
+TestCommand::TestCommand()
+: OptionsState("test")
+{
+	
+}

--- a/tools/orange/TestCommand.cc
+++ b/tools/orange/TestCommand.cc
@@ -38,9 +38,23 @@ void TestCommand::enableOutput()
 
 int TestCommand::run(std::vector<std::string> args)
 {
+	std::vector<std::string> test_files;
 	auto proj_dir = findProjectDirectory("orange.settings.json");
-	auto test_path = combinePaths(proj_dir, "test/");
-	auto test_files = getFilesRecursive(test_path, ".or");
+	
+	if (args.size() == 0)
+	{
+		auto test_path = combinePaths(proj_dir, "test/");
+    	test_files = getFilesRecursive(test_path, ".or");
+	}
+	else
+	{
+		for (unsigned int i = 0; i < args.size(); i++)
+		{
+			auto test_path = combinePaths(proj_dir, "test/" + args.at(i));
+			auto files = getFilesRecursive(test_path, ".or");
+			test_files.insert(test_files.end(), files.begin(), files.end());
+		}
+	}
 	
 	// Number of results (. or F) printed to the screen.
 	int nres_printed = 0;

--- a/tools/orange/main.cc
+++ b/tools/orange/main.cc
@@ -11,6 +11,7 @@
 #include <cmd/OptionsState.h>
 #include <orange/RunCommand.h>
 #include <orange/BuildCommand.h>
+#include <orange/TestCommand.h>
 
 
 int main(int argc, char** argv) {
@@ -18,7 +19,7 @@ int main(int argc, char** argv) {
 
 	auto runState = new RunCommand();
 	auto buildState = new BuildCommand();
-	auto testState = new OptionsState("test");
+	auto testState = new TestCommand();
 
 	options->addState(runState);
 	options->addState(buildState);

--- a/tools/orange/main.cc
+++ b/tools/orange/main.cc
@@ -26,14 +26,21 @@ int main(int argc, char** argv) {
 
 	options->getMainState()->setRunDelegate(runState);
 
+	int retCode = 0;
+	
 	try
 	{
     	// Run our program.
-    	return options->parse(argc, argv);
+    	retCode = options->parse(argc, argv);
 	}
 	catch (std::exception& e)
 	{
 		std::cerr << e.what() << std::endl;
-		return 1;
+		retCode = 1;
 	}
+	
+	delete runState;
+	delete buildState;
+	delete testState;
+	delete options;
 }


### PR DESCRIPTION
`test` has been added back as a state from the command line. It works as it used to: no arguments will run every test recursively in the `test/` folder.

Otherwise, the arguments passed in are expected to be subdirectories of `test/`, and they will be recursively searched to create a pool of tests to run.